### PR TITLE
fix: replace expect with panic_with_error! for AssetNotFound

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -1,5 +1,11 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Env, String, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, panic_with_error, symbol_short, Env, String, Symbol};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ContractError {
+    AssetNotFound = 1,
+}
 
 #[contracttype]
 #[derive(Clone)]
@@ -46,7 +52,7 @@ impl AssetRegistry {
         env.storage()
             .persistent()
             .get(&asset_key(asset_id))
-            .expect("asset not found")
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::AssetNotFound))
     }
 
     pub fn asset_count(env: Env) -> u64 {
@@ -77,5 +83,19 @@ mod tests {
         let asset = client.get_asset(&id);
         assert_eq!(asset.asset_id, 1);
         assert_eq!(asset.owner, owner);
+    }
+
+    #[test]
+    fn test_get_asset_not_found() {
+        let env = Env::default();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+        let result = client.try_get_asset(&999);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::AssetNotFound as u32
+            )))
+        );
     }
 }


### PR DESCRIPTION
Title: fix: replace expect with panic_with_error! for AssetNotFound

Body:

## Problem

get_asset was calling .expect("asset not found") which panics with a raw string. This produces an unstructured host 
error that callers cannot programmatically distinguish from other panics.

## Changes

- Added #[contracterror] enum ContractError with AssetNotFound = 1 variant
- Replaced .expect("asset not found") with .unwrap_or_else(|| panic_with_error!(&env, ContractError::AssetNotFound))
- Added test_get_asset_not_found test that asserts try_get_asset returns the correct structured contract error code

## Testing

bash
cargo test -p asset-registry


Both test_register_and_get_asset and test_get_asset_not_found pass.
closes #1