### PR TITLE
fix: prevent double revocation of engineer credentials

### DIFF
--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -54,6 +54,7 @@ impl EngineerRegistry {
             .get(&engineer_key(&engineer))
             .expect("engineer not found");
         assert!(record.issuer == issuer, "not the issuer");
+        assert!(record.active, "credential already revoked");
         record.active = false;
         env.storage().persistent().set(&engineer_key(&engineer), &record);
     }
@@ -102,5 +103,24 @@ mod tests {
         let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
 
         client.register_engineer(&engineer, &zero_hash, &issuer);
+    }
+
+    #[test]
+    #[should_panic(expected = "credential already revoked")]
+    fn test_double_revocation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(EngineerRegistry, ());
+        let client = EngineerRegistryClient::new(&env, &contract_id);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+
+        client.register_engineer(&engineer, &hash, &issuer);
+        client.revoke_credential(&engineer, &issuer);
+        
+        // Attempting to revoke again should panic
+        client.revoke_credential(&engineer, &issuer);
     }
 }


### PR DESCRIPTION
- Add check to ensure credential is active before revoking
- Prevent silent no-op when attempting to revoke already inactive credential
- Add test case for double-revocation scenario that verifies proper error handling

closes #5 