### PR TITLE
docs: add security policy and link in README (issue #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ Industrial assets like generators, turbines, and heavy vehicles represent trilli
 
 See [docs/roadmap.md](docs/roadmap.md) for details.
 
+## 🛡️ Security
+
+We take the security of Mainstay very seriously. If you discover a vulnerability, please refer to our [Security Policy](SECURITY.md) for reporting instructions.
+
 ## 🤝 Contributing
 
 We welcome contributions! Please:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of Mainstay are currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+| < 0.1   | :x:                |
+
+## Reporting a Vulnerability
+
+We take the security of Mainstay very seriously. If you believe you have found a security vulnerability in our smart contracts or core infrastructure, please report it to us as soon as possible.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+### Disclosure Process
+
+1.  **Report**: Send an email to [security@twintrust.io](mailto:security@twintrust.io) with details of the vulnerability.
+2.  **Acknowledgment**: We will acknowledge receipt of your report within 48 hours.
+3.  **Investigation**: Our team will investigate the issue and may contact you for further information.
+4.  **Resolution**: Once verified, we will work on a fix and coordinate a disclosure timeline.
+5.  **Recognition**: We value the work of security researchers and will provide credit in our release notes (unless you prefer to remain anonymous).
+
+### Responsible Disclosure Guidelines
+
+-   Provide sufficient detail to reproduce the vulnerability.
+-   Give us reasonable time to resolve the issue before making any information public.
+-   Avoid privacy violations, destruction of data, and interruption or degradation of our service.
+
+Thank you for helping us keep Mainstay secure!


### PR DESCRIPTION
Closes #49

---


PR Description: This PR addresses issue #49 by adding a formal Security Policy to the repository. Mainstay manages real asset collateral on-chain, and having a clear disclosure process is critical for maintaining project integrity and user trust.

Key changes:

Created SECURITY.md with reporting instructions and contact email.
Updated README.md with a security section to increase visibility of the policy.

issue #49 