### PR TITLE
test(lifecycle): verify submit_maintenance panics for unregistered engineer , Collateral Score Caps at 100.

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -835,6 +835,29 @@ mod tests {
     }
 
     #[test]
+    fn test_submit_maintenance_unregistered_engineer_should_panic() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, _, _) = setup(&env, 0);
+        let asset_id = register_asset(&env, &asset_registry_client);
+        let unregistered = Address::generate(&env);
+
+        let result = client.try_submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "Should fail"),
+            &unregistered,
+        );
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::UnauthorizedEngineer as u32,
+            ))),
+        );
+    }
+
+    #[test]
     fn test_collateral_score_caps_at_100() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION


Adds test_submit_maintenance_unregistered_engineer_should_panic to the
lifecycle contract test suite.

Test steps:
- Set up Lifecycle contract with real AssetRegistry and EngineerRegistry
  via the existing setup() helper (max_history = 0 → default 200)
- Register a valid asset via register_asset()
- Generate a fresh Address that is never passed to register_engineer,
  so it has no entry in the EngineerRegistry persistent storage
- Call try_submit_maintenance() with that address as the engineer
- Assert the return value is Err(UnauthorizedEngineer) (contract error 2),
  confirming the verify_engineer cross-contract call returns false for
  unknown addresses and the contract rejects the submission before any
  state is written
  
  closes #42 
  closes #44 