### PR TITLE
Add cross-platform test scripts and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,24 @@ This makes Mainstay:
 
 ### Test
 
+From the repository root, run the full workspace test suite (same as CI):
+
 ```bash
 ./scripts/test.sh
+```
+
+Optional arguments are forwarded to `cargo test`, for example:
+
+```bash
+./scripts/test.sh -p lifecycle
+./scripts/test.sh -p lifecycle my_test_name -- --nocapture
+```
+
+On Windows (PowerShell):
+
+```powershell
+.\scripts\test.ps1
+.\scripts\test.ps1 -p lifecycle
 ```
 
 ### Setup Environment

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -830,6 +830,32 @@ mod tests {
     }
 
     #[test]
+    fn test_decay_score_five_points_per_thirty_day_interval() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let asset_id = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+
+        for _ in 0..5 {
+            client.submit_maintenance(
+                &asset_id,
+                &symbol_short!("ENGINE"),
+                &String::from_str(&env, "Build score to 50"),
+                &engineer,
+            );
+        }
+        assert_eq!(client.get_collateral_score(&asset_id), 50);
+
+        env.ledger().with_mut(|li| li.timestamp = li.timestamp + 2 * DEFAULT_DECAY_INTERVAL);
+
+        let decayed = client.decay_score(&asset_id);
+        assert_eq!(decayed, 40);
+        assert_eq!(client.get_collateral_score(&asset_id), 40);
+    }
+
+    #[test]
     fn test_submit_maintenance_emits_event() {
         let env = Env::default();
         env.mock_all_auths();

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,0 +1,25 @@
+# Run Rust tests for the whole workspace (same as CI: cargo test --workspace).
+# Usage:
+#   .\scripts\test.ps1
+#   .\scripts\test.ps1 -p lifecycle
+#   .\scripts\test.ps1 -p lifecycle test_decay_score -- --nocapture
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $Root
+
+$Cargo = $null
+if (Get-Command cargo -ErrorAction SilentlyContinue) {
+    $Cargo = "cargo"
+} elseif (Test-Path "$env:USERPROFILE\.cargo\bin\cargo.exe") {
+    $Cargo = "$env:USERPROFILE\.cargo\bin\cargo.exe"
+}
+
+if (-not $Cargo) {
+    Write-Error "cargo not found. Install Rust from https://rustup.rs and ensure cargo is on PATH."
+}
+
+Write-Host "Running Mainstay tests (workspace) from $Root ..."
+& $Cargo test --workspace @args
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+Write-Host "All tests passed."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-source ~/.cargo/env 2>/dev/null || true
+# Repo root = parent of scripts/
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
 
-echo "Running Mainstay tests..."
-cargo test
+# rustup/cargo on macOS/Linux (non-login shells)
+if [[ -f "$HOME/.cargo/env" ]]; then
+  # shellcheck source=/dev/null
+  source "$HOME/.cargo/env"
+fi
+
+echo "Running Mainstay tests (workspace) from $ROOT ..."
+cargo test --workspace "$@"
 echo "All tests passed."


### PR DESCRIPTION
Closes #129

---

Runs the full Rust workspace test suite the same way as CI (cargo test --workspace).

Usage

macOS / Linux / Git Bash: from repo root
./scripts/test.sh
Optional filters: ./scripts/test.sh -p lifecycle or ./scripts/test.sh -p lifecycle my_test -- --nocapture

Windows (PowerShell): from repo root
.\scripts\test.ps1
Same optional args: .\scripts\test.ps1 -p lifecycle

Requires Rust/cargo on PATH (or cargo.exe under %USERPROFILE%\.cargo\bin on Windows).