### PR TITLE
test: update_asset_metadata removes old dedup key

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -811,6 +811,35 @@ mod tests {
     }
 
     #[test]
+    fn test_update_asset_metadata_removes_old_dedup_key() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let meta_a = String::from_str(&env, "Spec A");
+        let meta_b = String::from_str(&env, "Spec B");
+
+        // Register with metadata A, then update to B
+        let id = client.register_asset(&symbol_short!("GENSET"), &meta_a, &owner);
+        client.update_asset_metadata(&id, &owner, &meta_b);
+
+        // Old dedup key (A) is gone — owner can register metadata A again
+        let id2 = client.register_asset(&symbol_short!("GENSET"), &meta_a, &owner);
+        assert_ne!(id, id2);
+
+        // New dedup key (B) is present — owner cannot register metadata B again
+        let result = client.try_register_asset(&symbol_short!("GENSET"), &meta_b, &owner);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::DuplicateAsset as u32,
+            ))),
+        );
+    }
+
+    #[test]
     fn test_get_assets_by_owner_updated_after_deregister() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
close #164 

- Added test_update_asset_metadata_removes_old_dedup_key to the asset-registry test module — it:
  1. Registers an asset with metadata A
  2. Updates it to metadata B
  3. Asserts the owner can re-register metadata A (old dedup key gone) → succeeds
  4. Asserts the owner cannot register metadata B again (new dedup key present) → DuplicateAsset error
- All 26 asset-registry tests + full workspace (75 tests total) pass
