### PR TITLE
fix(engineer-registry): emit event in add_trusted_issuer

### DIFF
--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -173,6 +173,11 @@ impl EngineerRegistry {
             list.push_back(issuer.clone());
         }
         env.storage().instance().set(&issuer_list_key(), &list);
+
+        env.events().publish(
+            (symbol_short!("ISS_ADD"), admin),
+            (issuer,),
+        );
     }
 
     pub fn remove_trusted_issuer(env: Env, admin: Address, issuer: Address) {
@@ -640,5 +645,29 @@ mod tests {
             env.storage().persistent().get_ttl(&engineer_key(&engineer))
         });
         assert!(ttl > 0, "TTL must be extended after revocation");
+    }
+
+    #[test]
+    fn test_add_trusted_issuer_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let issuer = Address::generate(&env);
+        client.add_trusted_issuer(&admin, &issuer);
+
+        let events = env.events().all();
+        assert_eq!(events.len(), 1);
+
+        let (_, topics, data) = events.get(0).unwrap();
+
+        use soroban_sdk::TryIntoVal;
+        let t0: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+        let t1: Address = topics.get(1).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(t0, symbol_short!("ISS_ADD"));
+        assert_eq!(t1, admin);
+
+        let (emitted_issuer,): (Address,) = data.try_into_val(&env).unwrap();
+        assert_eq!(emitted_issuer, issuer);
     }
 }


### PR DESCRIPTION
Closes #109

---

## Problem

`add_trusted_issuer` updated the trust graph in storage but emitted no on-chain event. Off-chain indexers and monitoring systems had no way to detect when a new issuer was added, making the trust graph opaque to external observers.

## Changes

**`contracts/engineer-registry/src/lib.rs`**
- After the state write in `add_trusted_issuer`, publish an event:
  - **Topics:** `(symbol_short!("ISS_ADD"), admin)`
  - **Data:** `(issuer,)`

## Tests

- Added `test_add_trusted_issuer_emits_event`:
  - Calls `add_trusted_issuer`
  - Asserts exactly **1** event was emitted
  - Asserts topic[0] == `ISS_ADD`, topic[1] == `admin`
  - Asserts data contains the correct `issuer` address