### PR TITLE
fix(#322,#323): skip symlink test on Windows; add credential_management.ps1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "contracts/asset-registry",
     "contracts/engineer-registry",
     "contracts/lifecycle",
+    "tests",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ stellar keys generate deployer --network testnet
 ./scripts/deploy_testnet.sh
 ```
 
+## 📋 Examples
+
+- [Credential Management (bash)](examples/credential_management.sh) — register, verify, renew, and revoke engineer credentials on Linux/macOS
+- [Credential Management (PowerShell)](examples/credential_management.ps1) — equivalent workflow for Windows users
+
 ## 📖 Documentation
 
 - [Architecture Overview](docs/architecture.md)

--- a/examples/credential_management.ps1
+++ b/examples/credential_management.ps1
@@ -1,0 +1,71 @@
+# examples/credential_management.ps1
+# Credential rotation workflow for the Mainstay Engineer Registry.
+# Equivalent to examples/credential_management.sh for Windows users.
+#
+# Prerequisites: Stellar CLI installed and available on PATH.
+# Usage: .\examples\credential_management.ps1
+
+param(
+    [string]$Network   = "testnet",
+    [string]$RpcUrl    = "https://soroban-testnet.stellar.org",
+    [string]$Contract  = $env:CONTRACT_ENGINEER_REGISTRY,
+    [string]$Admin     = $env:ADMIN_ADDRESS,
+    [string]$Issuer    = $env:ISSUER_ADDRESS,
+    [string]$Engineer  = $env:ENGINEER_ADDRESS,
+    [string]$CredHash  = $env:CREDENTIAL_HASH,
+    # Validity period in seconds (default: 1 year)
+    [long]$ValidityPeriod = 31536000
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-Contract {
+    param([string[]]$Args)
+    stellar contract invoke `
+        --network $Network `
+        --rpc-url $RpcUrl `
+        --id $Contract `
+        -- @Args
+}
+
+# ── 1. Register engineer ──────────────────────────────────────────────────────
+Write-Host "Registering engineer $Engineer ..."
+Invoke-Contract register_engineer `
+    --engineer  $Engineer `
+    --credential_hash $CredHash `
+    --issuer    $Issuer `
+    --validity_period $ValidityPeriod
+
+# ── 2. Verify credential is active ───────────────────────────────────────────
+Write-Host "Verifying engineer credential ..."
+$active = Invoke-Contract verify_engineer --engineer $Engineer
+if ($active -ne "true") {
+    Write-Error "Verification failed: engineer is not active."
+}
+Write-Host "Credential verified: $active"
+
+# ── 3. Renew credential (rotation) ───────────────────────────────────────────
+Write-Host "Renewing credential for $Engineer ..."
+Invoke-Contract renew_credential `
+    --engineer        $Engineer `
+    --new_validity_period $ValidityPeriod
+
+# ── 4. Confirm status after renewal ──────────────────────────────────────────
+Write-Host "Checking engineer status after renewal ..."
+$status = Invoke-Contract get_engineer_status --engineer $Engineer
+Write-Host "Status: $status"
+
+# ── 5. Revoke credential ──────────────────────────────────────────────────────
+Write-Host "Revoking credential for $Engineer ..."
+Invoke-Contract revoke_credential --engineer $Engineer
+
+# ── 6. Confirm revocation ────────────────────────────────────────────────────
+Write-Host "Confirming revocation ..."
+$revoked = Invoke-Contract verify_engineer --engineer $Engineer
+Write-Host "Active after revocation: $revoked"
+if ($revoked -ne "false") {
+    Write-Error "Revocation check failed: engineer should not be active."
+}
+
+Write-Host "Credential management workflow completed successfully."

--- a/examples/credential_management.sh
+++ b/examples/credential_management.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# examples/credential_management.sh
+# Credential rotation workflow for the Mainstay Engineer Registry.
+#
+# Prerequisites: Stellar CLI installed and available on PATH.
+# Usage: ./examples/credential_management.sh
+
+set -euo pipefail
+
+NETWORK="${STELLAR_NETWORK:-testnet}"
+RPC_URL="${STELLAR_RPC_URL:-https://soroban-testnet.stellar.org}"
+CONTRACT="${CONTRACT_ENGINEER_REGISTRY:?CONTRACT_ENGINEER_REGISTRY not set}"
+ADMIN="${ADMIN_ADDRESS:?ADMIN_ADDRESS not set}"
+ISSUER="${ISSUER_ADDRESS:?ISSUER_ADDRESS not set}"
+ENGINEER="${ENGINEER_ADDRESS:?ENGINEER_ADDRESS not set}"
+CRED_HASH="${CREDENTIAL_HASH:?CREDENTIAL_HASH not set}"
+VALIDITY_PERIOD="${VALIDITY_PERIOD:-31536000}"  # 1 year in seconds
+
+invoke() {
+    stellar contract invoke \
+        --network "$NETWORK" \
+        --rpc-url "$RPC_URL" \
+        --id "$CONTRACT" \
+        -- "$@"
+}
+
+# 1. Register engineer
+echo "Registering engineer $ENGINEER ..."
+invoke register_engineer \
+    --engineer "$ENGINEER" \
+    --credential_hash "$CRED_HASH" \
+    --issuer "$ISSUER" \
+    --validity_period "$VALIDITY_PERIOD"
+
+# 2. Verify credential is active
+echo "Verifying engineer credential ..."
+active=$(invoke verify_engineer --engineer "$ENGINEER")
+[ "$active" = "true" ] || { echo "ERROR: verification failed"; exit 1; }
+echo "Credential verified: $active"
+
+# 3. Renew credential (rotation)
+echo "Renewing credential for $ENGINEER ..."
+invoke renew_credential \
+    --engineer "$ENGINEER" \
+    --new_validity_period "$VALIDITY_PERIOD"
+
+# 4. Confirm status after renewal
+echo "Checking engineer status after renewal ..."
+status=$(invoke get_engineer_status --engineer "$ENGINEER")
+echo "Status: $status"
+
+# 5. Revoke credential
+echo "Revoking credential for $ENGINEER ..."
+invoke revoke_credential --engineer "$ENGINEER"
+
+# 6. Confirm revocation
+echo "Confirming revocation ..."
+revoked=$(invoke verify_engineer --engineer "$ENGINEER")
+echo "Active after revocation: $revoked"
+[ "$revoked" = "false" ] || { echo "ERROR: revocation check failed"; exit 1; }
+
+echo "Credential management workflow completed successfully."

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "cross-platform-tests"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[test]]
+name = "cross_platform_tests"
+path = "cross_platform_tests.rs"

--- a/tests/cross_platform_tests.rs
+++ b/tests/cross_platform_tests.rs
@@ -1,0 +1,42 @@
+//! Cross-platform integration tests.
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    /// Verifies that symlinks are detected correctly on platforms that support
+    /// unprivileged symlink creation (Linux / macOS).  On Windows the test is
+    /// skipped with an explanatory message because creating symlinks requires
+    /// either elevated privileges or Developer Mode to be enabled.
+    #[test]
+    fn test_symlink_detection() {
+        #[cfg(windows)]
+        {
+            println!(
+                "SKIP test_symlink_detection: symlink creation requires elevated privileges \
+                 or Developer Mode on Windows."
+            );
+            return;
+        }
+
+        #[cfg(not(windows))]
+        {
+            let dir = std::env::temp_dir().join("mainstay_symlink_test");
+            fs::create_dir_all(&dir).expect("failed to create temp dir");
+
+            let target = dir.join("target_file.txt");
+            let link = dir.join("link_file.txt");
+
+            fs::write(&target, b"mainstay").expect("failed to write target");
+            std::os::unix::fs::symlink(&target, &link).expect("failed to create symlink");
+
+            let meta = fs::symlink_metadata(&link).expect("failed to read symlink metadata");
+            assert!(meta.file_type().is_symlink(), "expected a symlink");
+
+            // Cleanup
+            let _ = fs::remove_file(&link);
+            let _ = fs::remove_file(&target);
+            let _ = fs::remove_dir(&dir);
+        }
+    }
+}


### PR DESCRIPTION
closes #322 
closes #323 

## Summary

 — Cross-platform symlink test

- Added `tests/cross_platform_tests.rs` with `test_symlink_detection`
- On **Windows**: prints a skip message and returns early (no failure)
- On **Linux/macOS**: creates a real symlink, asserts `is_symlink()`, cleans up
- `std::os::unix::fs::symlink` is gated behind `#[cfg(not(windows))]` so it won't compile on Windows
- Added `tests/Cargo.toml` workspace member; updated root `Cargo.toml`

— PowerShell credential management example

- Added `examples/credential_management.ps1` covering the same six-step workflow as the bash version: register → verify → renew → status → revoke → confirm
- Added `examples/credential_management.sh` (bash version)
- Updated README with `📋 Examples` section linking both scripts

## Tested

- Bash script: logic verified against engineer-registry contract API
- PowerShell script: equivalent operations, `$ErrorActionPreference = Stop` for fail-fast behaviour
- Symlink test: `#[cfg(windows)]` guard confirmed at compile level