### PR TITLE
fix(lifecycle): reset_score now updates last_update_key (#352)

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -1242,13 +1242,19 @@ impl Lifecycle {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
 
+        let now = env.ledger().timestamp();
         env.storage().persistent().set(&score_key(asset_id), &0u32);
         env.storage()
             .persistent()
             .extend_ttl(&score_key(asset_id), 518400, 518400);
+        env.storage()
+            .persistent()
+            .set(&last_update_key(asset_id), &now);
+        env.storage()
+            .persistent()
+            .extend_ttl(&last_update_key(asset_id), 518400, 518400);
 
-        env.events()
-            .publish((EVENT_RST_SCR, asset_id), (admin, env.ledger().timestamp()));
+        env.events().publish((EVENT_RST_SCR, asset_id), (admin, now));
     }
 
     /// Check collateral eligibility for multiple assets in a single call.
@@ -3468,6 +3474,46 @@ mod tests {
         // Admin resets the score
         client.reset_score(&admin, &asset_id);
         assert_eq!(client.get_collateral_score(&asset_id), 0);
+    }
+
+    #[test]
+    fn test_decay_after_reset_uses_reset_timestamp() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, admin) = setup(&env, 0);
+        let asset_id = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+
+        // Build up a score, then reset
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("ENGINE"),
+            &String::from_str(&env, "Major overhaul"),
+            &engineer,
+        );
+        client.reset_score(&admin, &asset_id);
+
+        // Rebuild score after reset
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("ENGINE"),
+            &String::from_str(&env, "Post-reset work"),
+            &engineer,
+        );
+        let score_after_rebuild = client.get_collateral_score(&asset_id);
+        assert!(score_after_rebuild > 0);
+
+        // Advance time by less than one decay interval (default 2592000s / 30 days)
+        // so no decay should be applied
+        env.ledger().with_mut(|li| li.timestamp += 100);
+        let score_after_short_wait = client.decay_score(&asset_id);
+        assert_eq!(score_after_short_wait, score_after_rebuild);
+
+        // Advance time by one full decay interval and verify exactly one decay step
+        env.ledger().with_mut(|li| li.timestamp += 2592000);
+        let score_after_decay = client.decay_score(&asset_id);
+        assert_eq!(score_after_decay, score_after_rebuild.saturating_sub(5));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #352.

`reset_score` zeroed `score_key` but left `last_update_key` pointing at the old timestamp. The next `decay_score` call would compute elapsed time from that stale timestamp, potentially applying a large decay to a score that was already 0 or had just been rebuilt after a reset.

## Changes

- **`reset_score`**: after zeroing `score_key`, now also writes `env.ledger().timestamp()` to `last_update_key` and extends its TTL (518 400 ledgers), matching the pattern used by `apply_decay`.
- **New test `test_decay_after_reset_uses_reset_timestamp`**: builds a score, resets it, rebuilds it, then asserts no decay before one interval and exactly 5 points of decay after one 2 592 000 s interval.

## Testing

Rust toolchain is not available in this environment; CI will run the full suite. The fix and test follow identical patterns to the existing decay tests.