### PR TITLE
fix: enforce structured error for maintenance history out-of-bounds o…

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -19,6 +19,7 @@ pub enum ContractError {
     Paused = 9,
     InvalidTaskType = 10,
     PendingAdminAlreadyExists = 11,
+    IndexOutOfBounds = 12,
 }
 
 #[contracttype]
@@ -873,10 +874,13 @@ impl Lifecycle {
     /// # Arguments
     /// * `asset_id` - The unique identifier of the asset
     /// * `offset` - Zero-based start index for pagination
-    /// * `limit` - Maximum number of records to return
+    /// * `limit` - Maximum number of records to return (returns empty vec if 0)
     ///
     /// # Returns
     /// Vec containing the requested page of maintenance records
+    ///
+    /// # Panics
+    /// - [`ContractError::IndexOutOfBounds`] if `offset` >= history length
     pub fn get_maintenance_history_page(
         env: Env,
         asset_id: u64,
@@ -890,8 +894,11 @@ impl Lifecycle {
             .unwrap_or(Vec::new(&env));
 
         let len = history.len();
-        if offset >= len || limit == 0 {
+        if limit == 0 {
             return Vec::new(&env);
+        }
+        if offset >= len {
+            panic_with_error!(&env, ContractError::IndexOutOfBounds);
         }
 
         let end = (offset + limit).min(len);
@@ -1091,8 +1098,11 @@ impl Lifecycle {
             .unwrap_or_else(|| Vec::new(&env));
 
         let len = history.len();
-        if offset >= len || limit == 0 {
+        if limit == 0 {
             return Vec::new(&env);
+        }
+        if offset >= len {
+            panic_with_error!(&env, ContractError::IndexOutOfBounds);
         }
 
         let end = (offset + limit).min(len);
@@ -4128,18 +4138,38 @@ mod tests {
             client.get_maintenance_history_page(&asset_id, &4, &2).len(),
             1
         );
-        // Out-of-bounds offset → empty
-        assert_eq!(
-            client
-                .get_maintenance_history_page(&asset_id, &10, &2)
-                .len(),
-            0
-        );
-        // limit=0 → empty
+        // limit=0 -> empty (valid offset, zero limit)
         assert_eq!(
             client.get_maintenance_history_page(&asset_id, &0, &0).len(),
             0
         );
+    }
+
+    #[test]
+    fn test_get_maintenance_history_page_out_of_bounds() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let asset_id = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+
+        for _ in 0..3 {
+            client.submit_maintenance(
+                &asset_id,
+                &symbol_short!("OIL_CHG"),
+                &String::from_str(&env, "oil change"),
+                &engineer,
+            );
+        }
+
+        // offset == len (3) -> IndexOutOfBounds
+        let result = client.try_get_maintenance_history_page(&asset_id, &3, &2);
+        assert_eq!(result, Err(Ok(ContractError::IndexOutOfBounds)));
+
+        // offset >> len (10) -> IndexOutOfBounds
+        let result = client.try_get_maintenance_history_page(&asset_id, &10, &2);
+        assert_eq!(result, Err(Ok(ContractError::IndexOutOfBounds)));
     }
 
     #[test]


### PR DESCRIPTION
Description:
This PR fixes the ambiguous return behavior in get_maintenance_history_page. Previously, providing an offset equal to or greater than the history length resulted in an empty vector. This has been replaced with a structured error to allow calling agents and frontends to properly handle pagination boundaries.

Changes:

Error Handling: Added an explicit bounds check to get_maintenance_history_page.

API Consistency: Aligned this function with the error-handling patterns established in the recently updated engineering history functions.

Documentation: Updated function comments to clarify boundary condition behavior.

Unit Tests: Added regression tests to ensure offsets >= len are caught and handled as errors.

Technical Details:

Utilized the Error enum for consistency with the rest of the Soroban contract.

The fix ensures that "no data found" (legitimate empty set) is distinguishable from "invalid pagination parameters."

Checklist:

[x] Branch bugfix/maintenance-history-bounds-391 created and pushed.

[x] Verified that legitimate pagination still works correctly.

[x] Tests cover the exact edge case of offset == history_length.

[x] Linked to Issue #391.

closes #391 