### PR TITLE
fix: deduplicate asset IDs in engineer history (#345)

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -1636,6 +1636,23 @@ mod tests {
     }
 
     #[test]
+    fn test_engineer_history_no_duplicate_asset_id_on_repeated_maintenance() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let asset_id = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+
+        client.submit_maintenance(&asset_id, &symbol_short!("OIL_CHG"), &String::from_str(&env, "first"), &engineer);
+        client.submit_maintenance(&asset_id, &symbol_short!("INSPECT"), &String::from_str(&env, "second"), &engineer);
+
+        let history = client.get_engineer_maintenance_history(&engineer);
+        assert_eq!(history.len(), 1);
+        assert!(history.contains(&asset_id));
+    }
+
+    #[test]
     fn test_get_last_service_no_history() {
         let env = Env::default();
         env.mock_all_auths();


### PR DESCRIPTION
closes #354 

## Summary

`engineer_history_add` already contains a deduplication guard (linear scan before append), so no logic change is needed.

This PR adds the missing test that explicitly verifies repeated `submit_maintenance` calls for the same asset do not produce duplicate entries in the engineer's history list.

## Changes

- Added `test_engineer_history_no_duplicate_asset_id_on_repeated_maintenance`: submits two maintenance records for the same asset by the same engineer and asserts `get_engineer_maintenance_history` returns the asset ID exactly once.