### PR TITLE
fix(#351): append zero ScoreEntry to score_history_key on reset_score

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -1363,6 +1363,12 @@ impl Lifecycle {
         env.storage()
             .persistent()
             .extend_ttl(&last_update_key(asset_id), 518400, 518400);
+        score_history_push(
+            &env,
+            asset_id,
+            ScoreEntry { timestamp: now, score: 0 },
+            config.max_history,
+        );
 
         env.events().publish((EVENT_RST_SCR, asset_id), (admin, now));
     }
@@ -3807,6 +3813,32 @@ mod tests {
         // Admin resets the score
         client.reset_score(&admin, &asset_id);
         assert_eq!(client.get_collateral_score(&asset_id), 0);
+    }
+
+    #[test]
+    fn test_reset_score_appends_zero_to_score_history() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, admin) = setup(&env, 0);
+        let asset_id = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("ENGINE"),
+            &String::from_str(&env, "Major overhaul"),
+            &engineer,
+        );
+        let history_before = client.get_score_history(&asset_id);
+        assert!(history_before.len() > 0);
+        assert!(history_before.last_unchecked().score > 0);
+
+        client.reset_score(&admin, &asset_id);
+
+        let history_after = client.get_score_history(&asset_id);
+        assert_eq!(history_after.len(), history_before.len() + 1);
+        assert_eq!(history_after.last_unchecked().score, 0);
     }
 
     #[test]


### PR DESCRIPTION
After reset_score, get_score_history was still returning pre-reset entries. Now score_history_push is called with score=0 so callers see the reset reflected in the history.

Also adds test_reset_score_appends_zero_to_score_history to verify the last history entry has score 0 after a reset.
closes #351 