### PR TITLE
fix: resolve issues #393, #394, #395, #396

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -600,6 +600,17 @@ impl Lifecycle {
         // Validate task type early before cross-contract calls
         let weight = get_task_weight(&env, &task_type);
 
+        // Check history cap before cross-contract calls to avoid wasting gas
+        let mut history: Vec<MaintenanceRecord> = env
+            .storage()
+            .persistent()
+            .get(&history_key(asset_id))
+            .unwrap_or(Vec::new(&env));
+
+        if history.len() >= config.max_history {
+            panic_with_error!(&env, ContractError::HistoryCapReached);
+        }
+
         // Verify asset exists
         let asset_registry: Address = env
             .storage()
@@ -617,16 +628,6 @@ impl Lifecycle {
         let registry = engineer_registry::EngineerRegistryClient::new(&env, &registry_id);
         if !registry.verify_engineer(&engineer) {
             panic_with_error!(&env, ContractError::UnauthorizedEngineer);
-        }
-
-        let mut history: Vec<MaintenanceRecord> = env
-            .storage()
-            .persistent()
-            .get(&history_key(asset_id))
-            .unwrap_or(Vec::new(&env));
-
-        if history.len() >= config.max_history {
-            panic_with_error!(&env, ContractError::HistoryCapReached);
         }
 
         let timestamp = env.ledger().timestamp();
@@ -1124,6 +1125,15 @@ impl Lifecycle {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
 
+        let eng_registry: Address = env
+            .storage()
+            .instance()
+            .get(&ENG_REGISTRY)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+        if new_registry == eng_registry {
+            panic_with_error!(&env, ContractError::InvalidConfig);
+        }
+
         env.storage().instance().set(&ASSET_REGISTRY, &new_registry);
 
         env.events()
@@ -1165,6 +1175,15 @@ impl Lifecycle {
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
         if config.admin != admin {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
+        }
+
+        let asset_registry: Address = env
+            .storage()
+            .instance()
+            .get(&ASSET_REGISTRY)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+        if new_registry == asset_registry {
+            panic_with_error!(&env, ContractError::InvalidConfig);
         }
 
         env.storage().instance().set(&ENG_REGISTRY, &new_registry);
@@ -1496,6 +1515,43 @@ mod tests {
             &symbol_short!("OIL_CHG"),
             &String::from_str(&env, "over cap"),
             &engineer,
+        );
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::HistoryCapReached as u32,
+            ))),
+        );
+    }
+
+    #[test]
+    fn test_history_cap_checked_before_cross_contract_calls() {
+        // When the cap is already reached, HistoryCapReached must fire even if the
+        // engineer is not registered — proving the check happens before cross-contract calls.
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 3);
+        let asset_id = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+
+        for _ in 0..3 {
+            client.submit_maintenance(
+                &asset_id,
+                &symbol_short!("OIL_CHG"),
+                &String::from_str(&env, "ok"),
+                &engineer,
+            );
+        }
+
+        // Use an unregistered engineer — if cap check is first we get HistoryCapReached,
+        // not UnauthorizedEngineer.
+        let unregistered = Address::generate(&env);
+        let result = client.try_submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "over cap"),
+            &unregistered,
         );
         assert_eq!(
             result,
@@ -3722,6 +3778,23 @@ mod tests {
     }
 
     #[test]
+    fn test_update_asset_registry_rejects_same_address_as_engineer_registry() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, engineer_registry_client, admin) = setup(&env, 0);
+        let eng_registry_addr = engineer_registry_client.address.clone();
+
+        let result = client.try_update_asset_registry(&admin, &eng_registry_addr);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::InvalidConfig as u32,
+            ))),
+        );
+    }
+
+    #[test]
     fn test_update_engineer_registry_emits_reg_eng_topic() {
         let env = Env::default();
         env.mock_all_auths();
@@ -3737,6 +3810,23 @@ mod tests {
         let (_, topics, _data) = events.get(0).unwrap();
         let t0: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
         assert_eq!(t0, EVENT_REG_ENG);
+    }
+
+    #[test]
+    fn test_update_engineer_registry_rejects_same_address_as_asset_registry() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, _, admin) = setup(&env, 0);
+        let asset_registry_addr = asset_registry_client.address.clone();
+
+        let result = client.try_update_engineer_registry(&admin, &asset_registry_addr);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::InvalidConfig as u32,
+            ))),
+        );
     }
 
     // --- Issue #144: batch_submit_maintenance updates score_history_key ---
@@ -3998,6 +4088,71 @@ mod tests {
             assert!(env.storage().persistent().has(&score_key));
             assert!(env.storage().persistent().has(&score_history_key));
             assert!(env.storage().persistent().has(&last_update_key));
+        });
+    }
+
+    // --- Issue #396: score_history_push sets TTL on first creation and extends on subsequent writes ---
+
+    #[test]
+    fn test_score_history_ttl_set_on_first_creation() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let asset_id = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+
+        let score_history_key = (symbol_short!("SCHIST"), asset_id);
+        let contract_id = client.address.clone();
+
+        // Key must not exist before first maintenance
+        env.as_contract(&contract_id, || {
+            assert!(!env.storage().persistent().has(&score_history_key));
+        });
+
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "first"),
+            &engineer,
+        );
+
+        // After first write the key must exist (TTL was set)
+        env.as_contract(&contract_id, || {
+            assert!(env.storage().persistent().has(&score_history_key));
+        });
+    }
+
+    #[test]
+    fn test_score_history_ttl_extended_on_subsequent_writes() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let asset_id = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+
+        let score_history_key = (symbol_short!("SCHIST"), asset_id);
+        let contract_id = client.address.clone();
+
+        // First write — creates the entry
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "first"),
+            &engineer,
+        );
+
+        // Second write — extends TTL on an existing entry
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "second"),
+            &engineer,
+        );
+
+        env.as_contract(&contract_id, || {
+            assert!(env.storage().persistent().has(&score_history_key));
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes four smart contract bugs in the lifecycle contract.

---

### #393 — `submit_maintenance` history cap checked before cross-contract calls

**Problem:** The `history.len() >= config.max_history` guard ran *after* two cross-contract calls, wasting gas when the cap was already reached.

**Fix:** Read history and check the cap before `verify_asset_exists` and `verify_engineer`.

**Test:** `test_history_cap_checked_before_cross_contract_calls` — fills the cap then calls with an unregistered engineer; asserts `HistoryCapReached` (not `UnauthorizedEngineer`), proving ordering.

---

### #394 — `update_asset_registry` now enforces distinct-address invariant

**Problem:** `update_asset_registry` could set the asset registry to the same address as the current engineer registry, violating the invariant established in `initialize`.

**Fix:** Read `ENG_REGISTRY` after the admin check; panic with `InvalidConfig` if addresses match.

**Test:** `test_update_asset_registry_rejects_same_address_as_engineer_registry`

---

### #395 — `update_engineer_registry` now enforces distinct-address invariant

**Problem:** Symmetric to #394 — `update_engineer_registry` could set the engineer registry to the same address as the current asset registry.

**Fix:** Read `ASSET_REGISTRY` after the admin check; panic with `InvalidConfig` if addresses match.

**Test:** `test_update_engineer_registry_rejects_same_address_as_asset_registry`

---

### #396 — TTL coverage for `score_history_push` on first creation and subsequent writes

**Problem:** `score_history_push` correctly calls `extend_ttl` on every write, but this was untested.

**Fix:** Tests only (no production code change needed).

**Tests:**
- `test_score_history_ttl_set_on_first_creation` — asserts key absent before first write, present after.
- `test_score_history_ttl_extended_on_subsequent_writes` — asserts key still present after a second write.

---

Closes #393
Closes #394
Closes #395
Closes #396