### PR TITLE
fix: correct instance extend_ttl signature and borrow-after-move in upgrade

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -469,7 +469,7 @@ impl AssetRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().instance().set(&PAUSED_KEY, &true);
-        env.storage().instance().extend_ttl(&PAUSED_KEY, 518400, 518400);
+        env.storage().instance().extend_ttl(518400, 518400);
     }
 
     /// Admin-only function to unpause the contract.
@@ -483,7 +483,7 @@ impl AssetRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().instance().set(&PAUSED_KEY, &false);
-        env.storage().instance().extend_ttl(&PAUSED_KEY, 518400, 518400);
+        env.storage().instance().extend_ttl(518400, 518400);
     }
 
     /// Check if the contract is currently paused.
@@ -702,7 +702,7 @@ impl AssetRegistry {
 
         #[cfg(not(test))]
         {
-            env.deployer().update_current_contract_wasm(new_wasm_hash);
+            env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
         }
 
         env.events().publish(

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -396,7 +396,7 @@ impl EngineerRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().instance().set(&PAUSED_KEY, &true);
-        env.storage().instance().extend_ttl(&PAUSED_KEY, 518400, 518400);
+        env.storage().instance().extend_ttl(518400, 518400);
     }
 
     /// Admin-only function to unpause the contract.
@@ -410,7 +410,7 @@ impl EngineerRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().instance().set(&PAUSED_KEY, &false);
-        env.storage().instance().extend_ttl(&PAUSED_KEY, 518400, 518400);
+        env.storage().instance().extend_ttl(518400, 518400);
     }
 
     /// Check if the contract is currently paused.


### PR DESCRIPTION
closes #345 

Summary
fix: deduplicate asset IDs in `engineer_history_add`                                          
                                                                                                                             
                                                                                                
  engineer_history_add was unconditionally appending asset_id to the engineer's history list,   
  causing duplicate entries when the same engineer submits multiple maintenance records for the 
  same asset.                                                                                   
                                                                                                
  Added a check before appending so each asset ID appears at most once in an engineer's history.
  Also added a test verifying deduplication behavior.                                           
                                                                                                