### PR TITLE
fix(#374): prevent duplicate engineer in issuer list on re-registrati…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ Thumbs.db
 
 # Wasm build output
 *.wasm
+
+# Rust
+Cargo.lock

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -115,6 +115,9 @@ impl EngineerRegistry {
         if credential_hash == BytesN::from_array(&env, &[0u8; 32]) {
             panic_with_error!(&env, ContractError::InvalidCredentialHash);
         }
+        if validity_period == 0 {
+            panic_with_error!(&env, ContractError::InvalidValidityPeriod);
+        }
 
         // Check if engineer already has an active record
         if let Some(existing) = env
@@ -143,13 +146,15 @@ impl EngineerRegistry {
             .persistent()
             .extend_ttl(&engineer_key(&engineer), 518400, 518400);
 
-        // Track issuer → engineers mapping
+        // Track issuer → engineers mapping (avoid duplicates on re-registration after revoke)
         let mut list: Vec<Address> = env
             .storage()
             .persistent()
             .get(&issuer_engineers_key(&issuer))
             .unwrap_or(Vec::new(&env));
-        list.push_back(engineer.clone());
+        if !list.contains(engineer.clone()) {
+            list.push_back(engineer.clone());
+        }
         env.storage()
             .persistent()
             .set(&issuer_engineers_key(&issuer), &list);
@@ -396,7 +401,7 @@ impl EngineerRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().instance().set(&PAUSED_KEY, &true);
-        env.storage().instance().extend_ttl(&PAUSED_KEY, 518400, 518400);
+        env.storage().instance().extend_ttl(518400, 518400);
     }
 
     /// Admin-only function to unpause the contract.
@@ -410,7 +415,7 @@ impl EngineerRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().instance().set(&PAUSED_KEY, &false);
-        env.storage().instance().extend_ttl(&PAUSED_KEY, 518400, 518400);
+        env.storage().instance().extend_ttl(518400, 518400);
     }
 
     /// Check if the contract is currently paused.
@@ -519,6 +524,30 @@ impl EngineerRegistry {
             }
         }
         env.storage().instance().set(&issuer_list_key(), &new_list);
+
+        // Revoke all active engineers registered by this issuer
+        let engineers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&issuer_engineers_key(&issuer))
+            .unwrap_or(Vec::new(&env));
+        for engineer in engineers.iter() {
+            if let Some(mut record) = env
+                .storage()
+                .persistent()
+                .get::<_, Engineer>(&engineer_key(&engineer))
+            {
+                if record.active {
+                    record.active = false;
+                    env.storage()
+                        .persistent()
+                        .extend_ttl(&engineer_key(&engineer), 518400, 518400);
+                    env.storage()
+                        .persistent()
+                        .set(&engineer_key(&engineer), &record);
+                }
+            }
+        }
 
         env.events()
             .publish((symbol_short!("ISS_RM"), admin.clone()), (issuer,));
@@ -1384,7 +1413,7 @@ mod tests {
 
         // Advance past original expiry
         env.ledger()
-            .with_mut(|li| li.timestamp = li.timestamp + 1001);
+            .with_mut(|li| li.timestamp = li.timestamp + 86_401);
         assert!(!client.verify_engineer(&engineer));
 
         // Renew for another 86_400 seconds from now
@@ -1764,6 +1793,29 @@ assert_eq!(new_expires_at, previous_expires_at + 86_400);
         let new_hash = BytesN::from_array(&env, &[2u8; 32]);
         client.register_engineer(&engineer, &new_hash, &issuer, &31_536_000);
         assert!(client.verify_engineer(&engineer));
+    }
+
+    #[test]
+    fn test_no_duplicate_in_issuer_list_after_reregistration() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+        client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+        client.revoke_credential(&engineer);
+
+        let new_hash = BytesN::from_array(&env, &[2u8; 32]);
+        client.register_engineer(&engineer, &new_hash, &issuer, &31_536_000);
+
+        // Engineer address must appear exactly once in the issuer's list
+        let list = client.get_engineers_by_issuer(&issuer);
+        let count = list.iter().filter(|a| *a == engineer).count();
+        assert_eq!(count, 1, "Engineer address must not be duplicated after re-registration");
     }
 
     #[test]


### PR DESCRIPTION
- Check for existing entry in issuer_engineers_key before appending on re-registration
- Extend TTL of issuer_engineers_key on re-registration (already present, now guarded)
- Add test: test_no_duplicate_in_issuer_list_after_reregistration
- Fix pre-existing compile errors: instance().extend_ttl() wrong arg count in pause/unpause
- Fix pre-existing test failures:
  - test_renew_credential_extends_expiry: advance past 86_400 expiry (was 1001)
  - test_register_engineer_zero_validity_rejected: add validity_period == 0 guard
  - test_remove_trusted_issuer_revokes_engineers: revoke engineers on issuer removal
- Update .gitignore: add Cargo.lock
Closes #374 