### PR TITLE
fix(#373): only emit ISS_ADD event when issuer is newly added

### DIFF
--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -472,11 +472,12 @@ impl EngineerRegistry {
             .unwrap_or(Vec::new(&env));
         if !list.contains(issuer.clone()) {
             list.push_back(issuer.clone());
+            env.storage().instance().set(&issuer_list_key(), &list);
+            env.events()
+                .publish((symbol_short!("ISS_ADD"), admin), (issuer,));
+        } else {
+            env.storage().instance().set(&issuer_list_key(), &list);
         }
-        env.storage().instance().set(&issuer_list_key(), &list);
-
-        env.events()
-            .publish((symbol_short!("ISS_ADD"), admin), (issuer,));
     }
 
     /// Admin-only function to remove a trusted issuer.
@@ -1294,6 +1295,32 @@ mod tests {
 
         let (emitted_issuer,): (Address,) = data.try_into_val(&env).unwrap();
         assert_eq!(emitted_issuer, issuer);
+    }
+
+    #[test]
+    fn test_add_trusted_issuer_no_duplicate_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let issuer = Address::generate(&env);
+        client.add_trusted_issuer(&admin, &issuer);
+        // Adding the same issuer again should not emit a second ISS_ADD event
+        client.add_trusted_issuer(&admin, &issuer);
+
+        let events = env.events().all();
+        use soroban_sdk::TryIntoVal;
+        let iss_add_count = events
+            .iter()
+            .filter(|(_, topics, _)| {
+                topics
+                    .get(0)
+                    .and_then(|v| TryIntoVal::<_, Symbol>::try_into_val(&v, &env).ok())
+                    .map(|s| s == symbol_short!("ISS_ADD"))
+                    .unwrap_or(false)
+            })
+            .count();
+        assert_eq!(iss_add_count, 1, "ISS_ADD should only be emitted once");
     }
 
     #[test]


### PR DESCRIPTION
add_trusted_issuer correctly guarded the list push with !list.contains(issuer), but the ISS_ADD event was published unconditionally after that block — so calling the function with an already-trusted issuer would silently skip the duplicate list entry but still fire a spurious event.

Fix

Moved env.events().publish(...) inside the if !list.contains(...) branch so the event only fires when the issuer is genuinely new.

Test

Added test_add_trusted_issuer_no_duplicate_event — calls add_trusted_issuer twice with the same issuer and asserts exactly one ISS_ADD event is emitted.

Affected contract

contracts/engineer-registry

Closes #373 