### PR TITLE
Emit PROP_ADMIN and ADMIN_SET events in admin transfer functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "cross-platform-tests"
+version = "0.1.0"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -51,6 +51,7 @@ const PAUSED_KEY: Symbol = symbol_short!("PAUSED");
 const REG_ENG_TOPIC: Symbol = symbol_short!("REG_ENG");
 const REVOKE_TOPIC: Symbol = symbol_short!("REV_CRED");
 const MIN_VALIDITY_PERIOD: u64 = 86_400;
+const EVENT_PROP_ADMIN: Symbol = symbol_short!("PROP_ADMIN");
 
 fn is_paused(env: &Env) -> bool {
     env.storage().instance().get(&PAUSED_KEY).unwrap_or(false)
@@ -366,6 +367,8 @@ impl EngineerRegistry {
         env.storage()
             .instance()
             .set(&pending_admin_key(), &new_admin);
+        env.events()
+            .publish((EVENT_PROP_ADMIN,), (admin, new_admin));
     }
 
     /// Accept the admin transfer (step 2 of 2-step transfer).
@@ -1927,5 +1930,27 @@ assert_eq!(new_expires_at, previous_expires_at + 86_400);
             },
         }]);
         assert!(client.try_accept_admin().is_err());
+    }
+
+    #[test]
+    fn test_propose_admin_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let new_admin = Address::generate(&env);
+        client.propose_admin(&admin, &new_admin);
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+
+        use soroban_sdk::TryIntoVal;
+        let topic: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(topic, EVENT_PROP_ADMIN);
+
+        let (emitted_admin, emitted_new_admin): (Address, Address) =
+            data.try_into_val(&env).unwrap();
+        assert_eq!(emitted_admin, admin);
+        assert_eq!(emitted_new_admin, new_admin);
     }
 }

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -79,6 +79,8 @@ const EVENT_REG_AST: Symbol = symbol_short!("REG_AST");
 const EVENT_REG_ENG: Symbol = symbol_short!("REG_ENG");
 const EVENT_RST_SCR: Symbol = symbol_short!("RST_SCR");
 const EVENT_XFER: Symbol = symbol_short!("XFER");
+const EVENT_PROP_ADMIN: Symbol = symbol_short!("PROP_ADMIN");
+const EVENT_ADMIN_SET: Symbol = symbol_short!("ADMIN_SET");
 
 fn history_key(asset_id: u64) -> (Symbol, u64) {
     (symbol_short!("HIST"), asset_id)
@@ -440,6 +442,8 @@ impl Lifecycle {
             panic_with_error!(&env, ContractError::PendingAdminAlreadyExists);
         }
         env.storage().instance().set(&PENDING_ADMIN_KEY, &new_admin);
+        env.events()
+            .publish((EVENT_PROP_ADMIN,), (admin, new_admin));
     }
 
     /// Accept the admin transfer (step 2 of 2-step transfer).
@@ -461,10 +465,12 @@ impl Lifecycle {
             .persistent()
             .get(&CONFIG)
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
-        config.admin = pending_admin;
+        config.admin = pending_admin.clone();
         env.storage().persistent().set(&CONFIG, &config);
         env.storage().persistent().extend_ttl(&CONFIG, 518400, 518400);
         env.storage().instance().remove(&PENDING_ADMIN_KEY);
+        env.events()
+            .publish((EVENT_ADMIN_SET,), (pending_admin,));
     }
 
     /// Admin-only function to update the score increment configuration.
@@ -5116,5 +5122,50 @@ mod tests {
             "score history cleared after purge"
         );
       main
+    }
+
+    #[test]
+    fn test_propose_admin_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, _, admin) = setup(&env, 0);
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+
+        use soroban_sdk::TryIntoVal;
+        let topic: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(topic, EVENT_PROP_ADMIN);
+
+        let (emitted_admin, emitted_new_admin): (Address, Address) =
+            data.try_into_val(&env).unwrap();
+        assert_eq!(emitted_admin, admin);
+        assert_eq!(emitted_new_admin, new_admin);
+    }
+
+    #[test]
+    fn test_accept_admin_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, _, admin) = setup(&env, 0);
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+        client.accept_admin();
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+
+        use soroban_sdk::TryIntoVal;
+        let topic: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(topic, EVENT_ADMIN_SET);
+
+        let emitted_admin: Address = data.try_into_val(&env).unwrap();
+        assert_eq!(emitted_admin, new_admin);
     }
 }


### PR DESCRIPTION
closes #360 
closes #361 
closes #362

**PR Description**

## Fix: Missing events in admin transfer functions

Three functions across two contracts were silently mutating admin state without emitting events, making it impossible for off-chain monitors to track pending or completed admin transfers.

### Changes

**`contracts/lifecycle/src/lib.rs`**
- Added `EVENT_PROP_ADMIN` (`PROP_ADMIN`) and `EVENT_ADMIN_SET` (`ADMIN_SET`) constants
- `propose_admin` now emits `PROP_ADMIN` with `(current_admin, new_admin)` as data
- `accept_admin` now emits `ADMIN_SET` with the new admin address as data
- Added `test_propose_admin_emits_event` and `test_accept_admin_emits_event` tests

**`contracts/engineer-registry/src/lib.rs`**
- Added `EVENT_PROP_ADMIN` (`PROP_ADMIN`) constant
- `propose_admin` now emits `PROP_ADMIN` with `(current_admin, new_admin)` as data
- Added `test_propose_admin_emits_event` test

### Why
Off-chain monitors and indexers had no way to detect pending or finalized admin transfers. These events bring the lifecycle and engineer-registry contracts in line with the asset-registry, which already emits `PROP_ADM` on `propose_admin`.