### PR TITLE
fix(asset-registry): extend instance TTL in initialize_admin

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -408,6 +408,7 @@ impl AssetRegistry {
             panic_with_error!(&env, ContractError::AdminAlreadyInitialized);
         }
         env.storage().instance().set(&ADMIN_KEY, &admin);
+        env.storage().instance().extend_ttl(518400, 518400);
     }
 
     /// Get the current admin address of the contract.
@@ -487,10 +488,7 @@ impl AssetRegistry {
         env.storage().persistent().extend_ttl(&PAUSED_KEY, 518400, 518400);
         env.storage().instance().set(&PAUSED_KEY, &true);
         env.storage().instance().extend_ttl(518400, 518400);
-<<<<<<< fix/ci-compile-errors-instance-extend-ttl
-=======
         env.events().publish((symbol_short!("PAUSED"),), (admin,));
->>>>>>> main
     }
 
     /// Admin-only function to unpause the contract.
@@ -507,10 +505,7 @@ impl AssetRegistry {
         env.storage().persistent().extend_ttl(&PAUSED_KEY, 518400, 518400);
         env.storage().instance().set(&PAUSED_KEY, &false);
         env.storage().instance().extend_ttl(518400, 518400);
-<<<<<<< fix/ci-compile-errors-instance-extend-ttl
-=======
         env.events().publish((symbol_short!("UNPAUSED"),), (admin,));
->>>>>>> main
     }
 
     /// Check if the contract is currently paused.
@@ -2715,5 +2710,34 @@ mod tests {
                 .get_ttl(&owner_index_key(&owner));
             assert!(ttl > 0, "owner index TTL must be extended on read");
         });
+    }
+
+    // --- Issue #384: initialize_admin extends instance TTL after writing ADMIN_KEY ---
+
+    #[test]
+    fn test_admin_key_survives_ttl_boundary() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin);
+
+        // Verify instance TTL was extended after writing ADMIN_KEY
+        env.as_contract(&contract_id, || {
+            let ttl = env.storage().instance().get_ttl();
+            assert!(ttl > 0, "instance TTL must be extended after initialize_admin");
+        });
+
+        // Simulate TTL boundary: advance ledger sequence past the minimum TTL
+        // then verify get_admin still returns the correct admin
+        env.ledger().with_mut(|li| {
+            li.sequence_number += 518400;
+            li.timestamp += 518400 * 5;
+        });
+
+        // get_admin must still resolve correctly (TTL was extended at init time)
+        assert_eq!(client.get_admin(), admin);
     }
 }


### PR DESCRIPTION
## Summary

Closes #384

`initialize_admin` wrote `ADMIN_KEY` to instance storage without extending the instance TTL. If the instance TTL expired before any subsequent write, `get_admin` would return `NotInitialized` and all admin-gated functions would become inaccessible.

## Changes

- **`initialize_admin`**: add `env.storage().instance().extend_ttl(518400, 518400)` immediately after `instance().set(&ADMIN_KEY, &admin)`
- **`pause` / `unpause`**: resolve leftover merge conflicts — keep both the instance TTL extension and the event publish (PAUSED / UNPAUSED)
- **New test `test_admin_key_survives_ttl_boundary`**: verifies the instance TTL is extended after `initialize_admin` and that `get_admin` still resolves correctly after advancing the ledger past the TTL boundary

## Testing

- New test covers the TTL extension and post-boundary admin resolution
- Existing `test_pause_emits_event` / `test_unpause_emits_event` cover the conflict-resolved event publishes
- CI will run the full workspace test suite