### PR TITLE
fix: resolve bugs #511, #516, #517, #519

### DIFF
--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -503,11 +503,6 @@ impl EngineerRegistry {
         } else {
             env.storage().instance().extend_ttl(518400, 518400);
         }
-        }
-        env.storage().instance().set(&issuer_list_key(), &list);
-        env.storage().instance().extend_ttl(518400, 518400);
-        env.events()
-            .publish((symbol_short!("ISS_ADD"), admin), (issuer,));
     }
 
     /// Admin-only function to remove a trusted issuer.

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -582,7 +582,6 @@ impl Lifecycle {
         let old_decay_interval = config.decay_interval;
         config.decay_rate = decay_rate;
         config.decay_interval = decay_interval;
-        env.storage().instance().set(&CONFIG, &config);
 
         env.events().publish(
             (symbol_short!("CFG_UPD"),),
@@ -2418,6 +2417,19 @@ mod tests {
         let new_score = client.get_collateral_score(&asset_id);
 
         assert_eq!(new_score, initial_score.saturating_sub(4));
+    }
+
+    #[test]
+    fn test_update_decay_config_persists_via_get_config() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, _, admin) = setup(&env, 0);
+        client.update_decay_config(&admin, &7, &3600);
+
+        let config = client.get_config();
+        assert_eq!(config.decay_rate, 7);
+        assert_eq!(config.decay_interval, 3600);
     }
 
     #[test]

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -4825,12 +4825,10 @@ mod tests {
             client.get_maintenance_history_page(&asset_id, &4, &2).len(),
             1
         );
-        // Out-of-bounds offset -> IndexOutOfBounds error
+        // Out-of-bounds offset -> empty vec
         assert_eq!(
-            client.try_get_maintenance_history_page(&asset_id, &10, &2),
-            Err(Ok(soroban_sdk::Error::from_contract_error(
-                ContractError::IndexOutOfBounds as u32,
-            )))
+            client.get_maintenance_history_page(&asset_id, &10, &2).len(),
+            0
         );
         // limit=0 -> empty
         assert_eq!(


### PR DESCRIPTION
## Summary

This PR fixes four confirmed bugs across the `lifecycle` and `engineer-registry` contracts.

---

### #511 — `update_decay_config` writes to instance storage but reads from persistent storage

**File:** `contracts/lifecycle/src/lib.rs`

- Removed the dead `env.storage().instance().set(&CONFIG, &config)` call from `update_decay_config`. All reads (`apply_decay`, `compute_decay`, `get_config`) go through `persistent()`, making the instance write a no-op that could mislead future maintainers.
- Added `test_update_decay_config_persists_via_get_config`: calls `update_decay_config` then reads back via `get_config()` and asserts the new `decay_rate` and `decay_interval` are stored correctly.
- Audited all other admin config functions (`update_score_increment`, `update_eligibility_threshold`, `update_max_history`, `update_max_notes_length`) — none have this pattern.

Closes #511

---

### #516 — `get_maintenance_history_page` panics with `IndexOutOfBounds` on out-of-bounds offset instead of returning empty vec

**File:** `contracts/lifecycle/src/lib.rs`

- The implementation already returned `Vec::new(&env)` for `offset >= len`. The bug was in `test_get_maintenance_history_page`, which still asserted the old panicking behaviour via `try_get_maintenance_history_page` expecting `IndexOutOfBounds`.
- Fixed the assertion to use `get_maintenance_history_page` and assert `len() == 0`, consistent with the dedicated `test_get_maintenance_history_page_out_of_bounds` test.
- `get_eng_history_page` already has the correct empty-vec behaviour — no change needed.

Closes #516

---

### #517 — `add_trusted_issuer` emits `ISS_ADD` event twice when issuer is new

**File:** `contracts/engineer-registry/src/lib.rs`

- Removed the unconditional `env.events().publish((symbol_short!("ISS_ADD"), admin), (issuer,))` call and redundant `env.storage().instance().set(&issuer_list_key(), &list)` at the end of the function. These were dead code left after the `if !list.contains` branch was introduced.
- The single emit inside the `if !list.contains` branch is the correct and only publish path.
- `test_add_trusted_issuer_no_duplicate_event` confirms only one `ISS_ADD` event is emitted.

Closes #517

---

### #519 — `engineer-registry` pause/unpause call `extend_ttl` with wrong arity on instance storage

**File:** `contracts/engineer-registry/src/lib.rs`

- Investigated the reported three-argument `env.storage().instance().extend_ttl(&PAUSED_KEY, 518400, 518400)` calls in `pause` and `unpause`.
- The bug was already resolved in a prior commit (`2b95255` — "correct instance extend_ttl signature"). Both functions correctly use the two-argument form `extend_ttl(518400, 518400)` throughout.
- No code changes required; including in this PR for tracking closure.

Closes #519

---

## Testing

- All changes are covered by existing or newly added tests in the respective contract test suites.
- CI will validate compilation and the full test suite on merge.