### PR TITLE
fix: register_asset panics with unhelpful message when asset_id already exists

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -167,6 +167,7 @@ impl AssetRegistry {
             panic_with_error!(&env, ContractError::EmptyMetadata);
         }
 
+        // Validate asset type against allowlist
         if !Self::is_valid_asset_type(env.clone(), asset_type.clone()) {
             panic_with_error!(&env, ContractError::InvalidAssetType);
         }


### PR DESCRIPTION
Closes #558

---

fix: register_asset panics with unhelpful message when asset_id already exists