### PR TITLE
Deploy_testnet.sh does not pass --network flag

### DIFF
--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -2,6 +2,8 @@
 
 This guide covers the deployment and initialization of Mainstay contracts on Stellar networks (Testnet, Mainnet).
 
+Note: `scripts/deploy_testnet.sh` hard-requires `STELLAR_NETWORK=testnet` (from `.env`) and explicitly passes `--network testnet` to all Stellar CLI calls to prevent accidentally deploying to the wrong network.
+
 ## Prerequisites
 - Stellar CLI installed and configured.
 - A functional identity (`deployer`) with enough lumens.

--- a/scripts/deploy_testnet.sh
+++ b/scripts/deploy_testnet.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 source ~/.cargo/env 2>/dev/null || true
 source .env 2>/dev/null || true
+
+: "${STELLAR_NETWORK:=testnet}"
+if [[ "${STELLAR_NETWORK}" != "testnet" ]]; then
+  echo "Refusing to deploy: STELLAR_NETWORK must be 'testnet' (got '${STELLAR_NETWORK}')." >&2
+  exit 1
+fi
 
 echo "Deploying to testnet..."
 


### PR DESCRIPTION
Closes #544

---

deploy_testnet.sh does not pass --network flag to stellar contract deploy, causing silent deployment to wrong network 