### PR TITLE
refactor: replace bare 518400 TTL literals with named constants

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -47,6 +47,11 @@ const PAUSED_KEY: Symbol = symbol_short!("PAUSED");
 const ADMIN_KEY: Symbol = symbol_short!("ADMIN");
 const ASSET_TYPE_PREFIX: Symbol = symbol_short!("AST_TYPE");
 const PENDING_ADMIN_KEY: Symbol = symbol_short!("PADMIN");
+
+/// Soroban persistent-storage TTL constants.
+/// 1 ledger ≈ 5 seconds → 518_400 ledgers ≈ 30 days.
+const TTL_THRESHOLD: u32 = 518_400;
+const TTL_TARGET: u32 = 518_400;
 pub const DEREG_TOPIC: Symbol = symbol_short!("DEREG");
 pub const ADD_TYPE_TOPIC: Symbol = symbol_short!("ADD_TYPE");
 pub const RM_TYPE_TOPIC: Symbol = symbol_short!("RM_TYPE");
@@ -99,7 +104,7 @@ fn owner_index_add(env: &Env, owner: &Address, asset_id: u64) {
         .unwrap_or_else(|| Vec::new(env));
     ids.push_back(asset_id);
     env.storage().persistent().set(&key, &ids);
-    env.storage().persistent().extend_ttl(&key, 518400, 518400);
+    env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
 }
 
 /// Remove an asset ID from the owner's index.
@@ -128,7 +133,7 @@ fn owner_index_remove(env: &Env, owner: &Address, asset_id: u64) {
         }
     }
     env.storage().persistent().set(&key, &updated);
-    env.storage().persistent().extend_ttl(&key, 518400, 518400);
+    env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
 }
 
 fn is_paused(env: &Env) -> bool {
@@ -192,11 +197,11 @@ impl AssetRegistry {
         env.storage().persistent().set(&asset_key(id), &asset);
         env.storage()
             .persistent()
-            .extend_ttl(&asset_key(id), 518400, 518400); // Extend TTL for persistent storage entries to prevent data loss
+            .extend_ttl(&asset_key(id), TTL_THRESHOLD, TTL_TARGET); // Extend TTL for persistent storage entries to prevent data loss
         env.storage().persistent().set(&ASSET_COUNT, &id);
         env.storage()
             .persistent()
-            .extend_ttl(&ASSET_COUNT, 518400, 518400);
+            .extend_ttl(&ASSET_COUNT, TTL_THRESHOLD, TTL_TARGET);
         env.storage().persistent().set(&dk, &id);
 
         // Update owner index
@@ -267,13 +272,13 @@ impl AssetRegistry {
             env.storage().persistent().set(&asset_key(id), &asset);
             env.storage()
                 .persistent()
-                .extend_ttl(&asset_key(id), 518400, 518400);
+                .extend_ttl(&asset_key(id), TTL_THRESHOLD, TTL_TARGET);
             env.storage()
                 .persistent()
                 .set(&dedup_key(&owner, &meta_hash), &id);
             env.storage()
                 .persistent()
-                .extend_ttl(&dedup_key(&owner, &meta_hash), 518400, 518400);
+                .extend_ttl(&dedup_key(&owner, &meta_hash), TTL_THRESHOLD, TTL_TARGET);
 
             owner_index_add(&env, &owner, id);
 
@@ -296,14 +301,14 @@ impl AssetRegistry {
             env.storage().persistent().set(&ASSET_COUNT, &next_id);
             env.storage()
                 .persistent()
-                .extend_ttl(&ASSET_COUNT, 518400, 518400);
+                .extend_ttl(&ASSET_COUNT, TTL_THRESHOLD, TTL_TARGET);
         }
 
         // Ensure owner index TTL is extended after all batch writes
         if !ids.is_empty() {
             env.storage()
                 .persistent()
-                .extend_ttl(&owner_index_key(&owner), 518400, 518400);
+                .extend_ttl(&owner_index_key(&owner), TTL_THRESHOLD, TTL_TARGET);
         }
 
         // Emit batch registration event
@@ -348,7 +353,7 @@ impl AssetRegistry {
             .get(&key)
             .unwrap_or_else(|| Vec::new(&env));
         if env.storage().persistent().has(&key) {
-            env.storage().persistent().extend_ttl(&key, 518400, 518400);
+            env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
         }
         ids
     }
@@ -404,7 +409,7 @@ impl AssetRegistry {
             panic_with_error!(&env, ContractError::AdminAlreadyInitialized);
         }
         env.storage().instance().set(&ADMIN_KEY, &admin);
-        env.storage().instance().extend_ttl(518400, 518400);
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_TARGET);
     }
 
     /// Get the current admin address of the contract.
@@ -483,7 +488,7 @@ impl AssetRegistry {
         env.storage().persistent().set(&PAUSED_KEY, &true);
         env.storage()
             .persistent()
-            .extend_ttl(&PAUSED_KEY, 518400, 518400);
+            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
         env.events().publish((symbol_short!("PAUSED"),), (admin,));
     }
 
@@ -500,7 +505,7 @@ impl AssetRegistry {
         env.storage().persistent().set(&PAUSED_KEY, &false);
         env.storage()
             .persistent()
-            .extend_ttl(&PAUSED_KEY, 518400, 518400);
+            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
         env.events().publish((symbol_short!("UNPAUSED"),), (admin,));
     }
 
@@ -625,13 +630,13 @@ impl AssetRegistry {
         env.storage().persistent().set(&new_dk, &asset_id);
         env.storage()
             .persistent()
-            .extend_ttl(&new_dk, 518400, 518400);
+            .extend_ttl(&new_dk, TTL_THRESHOLD, TTL_TARGET);
         asset.metadata = new_metadata.clone();
         asset.metadata_updated_at = env.ledger().timestamp();
         env.storage().persistent().set(&asset_key(asset_id), &asset);
         env.storage()
             .persistent()
-            .extend_ttl(&asset_key(asset_id), 518400, 518400);
+            .extend_ttl(&asset_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
 
         env.events().publish(
             (symbol_short!("UPD_META"), asset_id),
@@ -681,7 +686,7 @@ impl AssetRegistry {
             .set(&dedup_key(&new_owner, &hash), &asset_id);
         env.storage()
             .persistent()
-            .extend_ttl(&dedup_key(&new_owner, &hash), 518400, 518400);
+            .extend_ttl(&dedup_key(&new_owner, &hash), TTL_THRESHOLD, TTL_TARGET);
 
         // Move owner index entry
         owner_index_remove(&env, &current_owner, asset_id);
@@ -691,7 +696,7 @@ impl AssetRegistry {
         env.storage().persistent().set(&asset_key(asset_id), &asset);
         env.storage()
             .persistent()
-            .extend_ttl(&asset_key(asset_id), 518400, 518400);
+            .extend_ttl(&asset_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
 
         env.events().publish(
             (symbol_short!("TRANSFER"), asset_id),
@@ -750,7 +755,7 @@ impl AssetRegistry {
             .set(&asset_type_key(&asset_type), &true);
         env.storage()
             .persistent()
-            .extend_ttl(&asset_type_key(&asset_type), 518400, 518400);
+            .extend_ttl(&asset_type_key(&asset_type), TTL_THRESHOLD, TTL_TARGET);
         env.events().publish((ADD_TYPE_TOPIC,), (asset_type,));
     }
 
@@ -2834,8 +2839,8 @@ mod tests {
         // Simulate TTL boundary: advance ledger sequence past the minimum TTL
         // then verify get_admin still returns the correct admin
         env.ledger().with_mut(|li| {
-            li.sequence_number += 518400;
-            li.timestamp += 518400 * 5;
+            li.sequence_number += TTL_THRESHOLD;
+            li.timestamp += TTL_THRESHOLD * 5;
         });
 
         // get_admin must still resolve correctly (TTL was extended at init time)

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -54,6 +54,12 @@ const REVOKE_TOPIC: Symbol = symbol_short!("REV_CRED");
 const MIN_VALIDITY_PERIOD: u64 = 86_400;
 const EVENT_PROP_ADMIN: Symbol = symbol_short!("PROP_ADM");
 
+
+/// Soroban persistent-storage TTL constants.
+/// 1 ledger ≈ 5 seconds → 518_400 ledgers ≈ 30 days.
+const TTL_THRESHOLD: u32 = 518_400;
+const TTL_TARGET: u32 = 518_400;
+
 fn is_paused(env: &Env) -> bool {
     env.storage().persistent().get(&PAUSED_KEY).unwrap_or(false)
 }
@@ -156,7 +162,7 @@ impl EngineerRegistry {
             .set(&engineer_key(&engineer), &record);
         env.storage()
             .persistent()
-            .extend_ttl(&engineer_key(&engineer), 518400, 518400);
+            .extend_ttl(&engineer_key(&engineer), TTL_THRESHOLD, TTL_TARGET);
 
         // Track issuer → engineers mapping (avoid duplicates on re-registration after revoke)
         let mut list: Vec<Address> = env
@@ -172,7 +178,7 @@ impl EngineerRegistry {
             .set(&issuer_engineers_key(&issuer), &list);
         env.storage()
             .persistent()
-            .extend_ttl(&issuer_engineers_key(&issuer), 518400, 518400);
+            .extend_ttl(&issuer_engineers_key(&issuer), TTL_THRESHOLD, TTL_TARGET);
 
         // Emit engineer registration event
         env.events().publish(
@@ -224,7 +230,7 @@ impl EngineerRegistry {
         // Extend TTL before write to ensure consistency even on near-expired entries
         env.storage()
             .persistent()
-            .extend_ttl(&engineer_key(&engineer), 518400, 518400);
+            .extend_ttl(&engineer_key(&engineer), TTL_THRESHOLD, TTL_TARGET);
         record.active = false;
         env.storage()
             .persistent()
@@ -274,7 +280,7 @@ impl EngineerRegistry {
         record.expires_at = renewal_base + new_validity_period;
         env.storage()
             .persistent()
-            .extend_ttl(&engineer_key(&engineer), 518400, 518400);
+            .extend_ttl(&engineer_key(&engineer), TTL_THRESHOLD, TTL_TARGET);
         env.storage()
             .persistent()
             .set(&engineer_key(&engineer), &record);
@@ -345,7 +351,7 @@ impl EngineerRegistry {
             panic_with_error!(&env, ContractError::AdminAlreadyInitialized);
         }
         env.storage().instance().set(&admin_key(), &admin);
-        env.storage().instance().extend_ttl(518400, 518400);
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_TARGET);
     }
 
     /// Get the current admin address of the contract.
@@ -420,7 +426,7 @@ impl EngineerRegistry {
         env.storage().persistent().set(&PAUSED_KEY, &true);
         env.storage()
             .persistent()
-            .extend_ttl(&PAUSED_KEY, 518400, 518400);
+            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
         env.events().publish((symbol_short!("PAUSED"),), (admin,));
     }
 
@@ -437,7 +443,7 @@ impl EngineerRegistry {
         env.storage().persistent().set(&PAUSED_KEY, &false);
         env.storage()
             .persistent()
-            .extend_ttl(&PAUSED_KEY, 518400, 518400);
+            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
         env.events().publish((symbol_short!("UNPAUSED"),), (admin,));
     }
 
@@ -501,11 +507,11 @@ impl EngineerRegistry {
         if !list.contains(issuer.clone()) {
             list.push_back(issuer.clone());
             env.storage().instance().set(&issuer_list_key(), &list);
-            env.storage().instance().extend_ttl(518400, 518400);
+            env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_TARGET);
             env.events()
                 .publish((symbol_short!("ISS_ADD"), admin), (issuer,));
         } else {
-            env.storage().instance().extend_ttl(518400, 518400);
+            env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_TARGET);
         }
     }
 
@@ -549,7 +555,7 @@ impl EngineerRegistry {
             }
         }
         env.storage().instance().set(&issuer_list_key(), &new_list);
-        env.storage().instance().extend_ttl(518400, 518400);
+        env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_TARGET);
 
         // Revoke all active engineers registered by this issuer
         let engineers: Vec<Address> = env
@@ -567,7 +573,7 @@ impl EngineerRegistry {
                     record.active = false;
                     env.storage()
                         .persistent()
-                        .extend_ttl(&engineer_key(&engineer), 518400, 518400);
+                        .extend_ttl(&engineer_key(&engineer), TTL_THRESHOLD, TTL_TARGET);
                     env.storage()
                         .persistent()
                         .set(&engineer_key(&engineer), &record);

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -83,6 +83,11 @@ const EVENT_XFER: Symbol = symbol_short!("XFER");
 const EVENT_PROP_ADMIN: Symbol = symbol_short!("PROP_ADM");
 const EVENT_ADMIN_SET: Symbol = symbol_short!("ADMIN_SET");
 
+/// Soroban persistent-storage TTL constants.
+/// 1 ledger ≈ 5 seconds → 518_400 ledgers ≈ 30 days.
+const TTL_THRESHOLD: u32 = 518_400;
+const TTL_TARGET: u32 = 518_400;
+
 fn history_key(asset_id: u64) -> (Symbol, u64) {
     (symbol_short!("HIST"), asset_id)
 }
@@ -109,7 +114,7 @@ fn score_history_push(env: &Env, asset_id: u64, entry: ScoreEntry, max_history: 
     }
     history.push_back(entry);
     env.storage().persistent().set(&key, &history);
-    env.storage().persistent().extend_ttl(&key, 518400, 518400);
+    env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
 }
 
 fn last_update_key(asset_id: u64) -> (Symbol, u64) {
@@ -145,7 +150,7 @@ fn engineer_history_add(env: &Env, engineer: &Address, asset_id: u64, max_histor
     }
 
     env.storage().persistent().set(&key, &ids);
-    env.storage().persistent().extend_ttl(&key, 518400, 518400);
+    env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
 }
 
 fn engineer_history_remove(env: &Env, engineer: &Address, asset_id: u64) {
@@ -161,7 +166,7 @@ fn engineer_history_remove(env: &Env, engineer: &Address, asset_id: u64) {
         if let Some(i) = index {
             ids.remove(i);
             env.storage().persistent().set(&key, &ids);
-            env.storage().persistent().extend_ttl(&key, 518400, 518400);
+            env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
         }
     }
 }
@@ -184,14 +189,14 @@ fn set_asset_registry_addr(env: &Env, addr: &Address) {
     env.storage().persistent().set(&ASSET_REGISTRY, addr);
     env.storage()
         .persistent()
-        .extend_ttl(&ASSET_REGISTRY, 518400, 518400);
+        .extend_ttl(&ASSET_REGISTRY, TTL_THRESHOLD, TTL_TARGET);
 }
 
 fn set_engineer_registry_addr(env: &Env, addr: &Address) {
     env.storage().persistent().set(&ENG_REGISTRY, addr);
     env.storage()
         .persistent()
-        .extend_ttl(&ENG_REGISTRY, 518400, 518400);
+        .extend_ttl(&ENG_REGISTRY, TTL_THRESHOLD, TTL_TARGET);
 }
 
 fn is_zero_address(env: &Env, addr: &Address) -> bool {
@@ -256,7 +261,7 @@ fn apply_decay(
         if env.storage().persistent().has(&last_update_key(asset_id)) {
             env.storage()
                 .persistent()
-                .extend_ttl(&last_update_key(asset_id), 518400, 518400);
+                .extend_ttl(&last_update_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
         }
         return 0;
     }
@@ -281,10 +286,10 @@ fn apply_decay(
     if decay_intervals == 0 && !update_on_zero_interval {
         env.storage()
             .persistent()
-            .extend_ttl(&score_key(asset_id), 518400, 518400);
+            .extend_ttl(&score_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
         env.storage()
             .persistent()
-            .extend_ttl(&last_update_key(asset_id), 518400, 518400);
+            .extend_ttl(&last_update_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
         return current_score;
     }
 
@@ -296,13 +301,13 @@ fn apply_decay(
         .set(&score_key(asset_id), &new_score);
     env.storage()
         .persistent()
-        .extend_ttl(&score_key(asset_id), 518400, 518400);
+        .extend_ttl(&score_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
     env.storage()
         .persistent()
         .set(&last_update_key(asset_id), &current_time);
     env.storage()
         .persistent()
-        .extend_ttl(&last_update_key(asset_id), 518400, 518400);
+        .extend_ttl(&last_update_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
 
     score_history_push(
         env,
@@ -425,7 +430,7 @@ impl Lifecycle {
         env.storage().persistent().set(&CONFIG, &config);
         env.storage()
             .persistent()
-            .extend_ttl(&CONFIG, 518400, 518400);
+            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
 
         env.events()
             .publish((EVENT_INIT,), (asset_registry, engineer_registry, admin));
@@ -452,7 +457,7 @@ impl Lifecycle {
         env.storage().persistent().set(&PAUSED_KEY, &true);
         env.storage()
             .persistent()
-            .extend_ttl(&PAUSED_KEY, 518400, 518400);
+            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
         env.events().publish((symbol_short!("PAUSED"),), (admin,));
     }
 
@@ -477,7 +482,7 @@ impl Lifecycle {
         env.storage().persistent().set(&PAUSED_KEY, &false);
         env.storage()
             .persistent()
-            .extend_ttl(&PAUSED_KEY, 518400, 518400);
+            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
         env.events().publish((symbol_short!("UNPAUSED"),), (admin,));
     }
 
@@ -541,7 +546,7 @@ impl Lifecycle {
         env.storage().persistent().set(&CONFIG, &config);
         env.storage()
             .persistent()
-            .extend_ttl(&CONFIG, 518400, 518400);
+            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
         env.storage().instance().remove(&PENDING_ADMIN_KEY);
         env.events().publish((EVENT_ADMIN_SET,), (pending_admin,));
     }
@@ -579,7 +584,7 @@ impl Lifecycle {
         env.storage().persistent().set(&CONFIG, &config);
         env.storage()
             .persistent()
-            .extend_ttl(&CONFIG, 518400, 518400);
+            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
         env.events().publish(
             (symbol_short!("CFG_UPD"),),
             (old_increment, score_increment),
@@ -632,7 +637,7 @@ impl Lifecycle {
         env.storage().persistent().set(&CONFIG, &config);
         env.storage()
             .persistent()
-            .extend_ttl(&CONFIG, 518400, 518400);
+            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
     }
 
     /// Admin-only function to update the eligibility threshold for collateral scoring.
@@ -666,7 +671,7 @@ impl Lifecycle {
         env.storage().persistent().set(&CONFIG, &config);
         env.storage()
             .persistent()
-            .extend_ttl(&CONFIG, 518400, 518400);
+            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
         env.events()
             .publish((symbol_short!("CFG_UPD"),), (old_threshold, threshold));
     }
@@ -709,7 +714,7 @@ impl Lifecycle {
         env.storage().persistent().set(&CONFIG, &config);
         env.storage()
             .persistent()
-            .extend_ttl(&CONFIG, 518400, 518400);
+            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
 
         env.events()
             .publish((symbol_short!("UPD_MAX"), admin), new_max);
@@ -746,7 +751,7 @@ impl Lifecycle {
         env.storage().persistent().set(&CONFIG, &config);
         env.storage()
             .persistent()
-            .extend_ttl(&CONFIG, 518400, 518400);
+            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
 
         env.events()
             .publish((symbol_short!("UPD_NOTES"), admin), new_max);
@@ -829,7 +834,7 @@ impl Lifecycle {
             .set(&history_key(asset_id), &history);
         env.storage()
             .persistent()
-            .extend_ttl(&history_key(asset_id), 518400, 518400);
+            .extend_ttl(&history_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
 
         engineer_history_add(&env, &engineer, asset_id, config.max_history);
 
@@ -845,7 +850,7 @@ impl Lifecycle {
             .set(&score_key(asset_id), &new_score);
         env.storage()
             .persistent()
-            .extend_ttl(&score_key(asset_id), 518400, 518400);
+            .extend_ttl(&score_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
 
         // Append (timestamp, score) snapshot to score history
         score_history_push(
@@ -864,7 +869,7 @@ impl Lifecycle {
             .set(&last_update_key(asset_id), &timestamp);
         env.storage()
             .persistent()
-            .extend_ttl(&last_update_key(asset_id), 518400, 518400);
+            .extend_ttl(&last_update_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
 
         // Emit maintenance submission event
         env.events()
@@ -926,7 +931,7 @@ impl Lifecycle {
             .set(&history_key(asset_id), &history);
         env.storage()
             .persistent()
-            .extend_ttl(&history_key(asset_id), 518400, 518400);
+            .extend_ttl(&history_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
 
         env.events().publish(
             (EVENT_XFER, asset_id),
@@ -1029,17 +1034,17 @@ impl Lifecycle {
             .set(&history_key(asset_id), &history);
         env.storage()
             .persistent()
-            .extend_ttl(&history_key(asset_id), 518400, 518400);
+            .extend_ttl(&history_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
         env.storage().persistent().set(&score_key(asset_id), &score);
         env.storage()
             .persistent()
-            .extend_ttl(&score_key(asset_id), 518400, 518400);
+            .extend_ttl(&score_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
         env.storage()
             .persistent()
             .set(&last_update_key(asset_id), &timestamp);
         env.storage()
             .persistent()
-            .extend_ttl(&last_update_key(asset_id), 518400, 518400);
+            .extend_ttl(&last_update_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
     }
 
     /// Apply time-based decay to an asset's collateral score.
@@ -1509,13 +1514,13 @@ impl Lifecycle {
         env.storage().persistent().set(&score_key(asset_id), &0u32);
         env.storage()
             .persistent()
-            .extend_ttl(&score_key(asset_id), 518400, 518400);
+            .extend_ttl(&score_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
         env.storage()
             .persistent()
             .set(&last_update_key(asset_id), &now);
         env.storage()
             .persistent()
-            .extend_ttl(&last_update_key(asset_id), 518400, 518400);
+            .extend_ttl(&last_update_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
         score_history_push(
             &env,
             asset_id,
@@ -1603,7 +1608,7 @@ impl Lifecycle {
                 env.storage().persistent().set(&history_key, &pruned);
                 env.storage()
                     .persistent()
-                    .extend_ttl(&history_key, 518400, 518400);
+                    .extend_ttl(&history_key, TTL_THRESHOLD, TTL_TARGET);
             }
         }
 
@@ -1626,7 +1631,7 @@ impl Lifecycle {
                     .set(&score_history_key_val, &pruned);
                 env.storage()
                     .persistent()
-                    .extend_ttl(&score_history_key_val, 518400, 518400);
+                    .extend_ttl(&score_history_key_val, TTL_THRESHOLD, TTL_TARGET);
             }
         }
 


### PR DESCRIPTION
Closes #534

---

## Summary

Replaces all 60 bare `518400` integer literals across the three contracts with two named constants, making the TTL strategy self-documenting and reducing future update risk to a single change per contract.

## Changes

Each contract now defines:
```rust
/// Soroban persistent-storage TTL constants.
/// 1 ledger ≈ 5 seconds → 518_400 ledgers ≈ 30 days.
const TTL_THRESHOLD: u32 = 518_400;
const TTL_TARGET: u32 = 518_400;
```

All `extend_ttl($key, 518400, 518400)` calls replaced with `extend_ttl($key, TTL_THRESHOLD, TTL_TARGET)`.

| Contract | Literals replaced |
|---|---|
| asset-registry | 19 |
| engineer-registry | 11 |
| lifecycle | 30 |

No behaviour change.