### PR TITLE
fix: remove owner index key instead of writing empty vec

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -127,8 +127,12 @@ fn owner_index_remove(env: &Env, owner: &Address, asset_id: u64) {
             updated.push_back(id);
         }
     }
-    env.storage().persistent().set(&key, &updated);
-    env.storage().persistent().extend_ttl(&key, 518400, 518400);
+    if updated.is_empty() {
+        env.storage().persistent().remove(&key);
+    } else {
+        env.storage().persistent().set(&key, &updated);
+        env.storage().persistent().extend_ttl(&key, 518400, 518400);
+    }
 }
 
 fn is_paused(env: &Env) -> bool {
@@ -1703,6 +1707,32 @@ mod tests {
             idx_miss_event.is_some(),
             "IDX_MISS diagnostic event must be emitted when owner index is missing"
         );
+    }
+
+    #[test]
+    fn test_owner_index_key_removed_after_last_asset_deregistered() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin);
+        client.add_asset_type(&admin, &symbol_short!("GENSET"));
+
+        let owner = Address::generate(&env);
+        let id = client.register_asset(
+            &symbol_short!("GENSET"),
+            &String::from_str(&env, "CAT-3516"),
+            &owner,
+        );
+
+        client.deregister_asset(&admin, &id);
+
+        let key_exists = env.as_contract(&contract_id, || {
+            env.storage().persistent().has(&owner_index_key(&owner))
+        });
+        assert!(!key_exists, "owner index key must be absent after last asset is removed");
     }
 
     #[test]


### PR DESCRIPTION
Closes #535

---

## Problem
When `owner_index_remove` filters out the last asset ID, the resulting `updated` vec is empty. The function still called `set(&key, &updated)` and `extend_ttl`, writing an empty vec and wasting storage and TTL budget.

## Changes
- After filtering, check `updated.is_empty()`: if true, call `remove(&key)`; otherwise `set` + `extend_ttl` as before.
- Add `test_owner_index_key_removed_after_last_asset_deregistered`: registers one asset, deregisters it, then asserts the owner index key is absent in persistent storage.

Closes #536 