### PR TITLE
fix: restrict initialization to contract deployer

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -394,12 +394,13 @@ impl AssetRegistry {
     /// This function should be called once immediately after deployment.
     ///
     /// # Arguments
+    /// * `deployer` - The address of the contract deployer; must sign this transaction.
     /// * `admin` - The address that will have administrative privileges
     ///
     /// # Panics
     /// - [`ContractError::AdminAlreadyInitialized`] if admin has already been initialized
-    pub fn initialize_admin(env: Env, admin: Address) {
-        admin.require_auth();
+    pub fn initialize_admin(env: Env, deployer: Address, admin: Address) {
+        deployer.require_auth();
         if env.storage().instance().has(&ADMIN_KEY) {
             panic_with_error!(&env, ContractError::AdminAlreadyInitialized);
         }
@@ -851,7 +852,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -875,7 +876,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("TURBINE"));
 
         let expected_owner = Address::generate(&env);
@@ -911,7 +912,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -939,7 +940,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner_a = Address::generate(&env);
@@ -960,7 +961,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -982,7 +983,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1015,7 +1016,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         let new_wasm_hash = BytesN::from_array(&env, &[0xabu8; 32]);
         let result = client.try_upgrade(&admin, &new_wasm_hash);
@@ -1035,7 +1036,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         let outsider = Address::generate(&env);
         let new_wasm_hash = BytesN::from_array(&env, &[0xabu8; 32]);
@@ -1058,7 +1059,7 @@ mod tests {
 
         let admin = Address::generate(&env);
         let new_admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         client.propose_admin(&admin, &new_admin);
         client.accept_admin(&new_admin);
@@ -1075,7 +1076,7 @@ mod tests {
 
         let admin = Address::generate(&env);
         let new_admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         client.propose_admin(&admin, &new_admin);
         client.accept_admin(&new_admin);
@@ -1100,7 +1101,7 @@ mod tests {
 
         let admin = Address::generate(&env);
         let new_admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         client.propose_admin(&admin, &new_admin);
         client.accept_admin(&new_admin);
@@ -1120,7 +1121,7 @@ mod tests {
         let admin = Address::generate(&env);
         let outsider = Address::generate(&env);
         let new_admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         let result = client.try_propose_admin(&outsider, &new_admin);
         assert_eq!(
@@ -1140,7 +1141,7 @@ mod tests {
 
         let admin = Address::generate(&env);
         let new_admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         client.propose_admin(&admin, &new_admin);
 
@@ -1168,7 +1169,7 @@ mod tests {
         let admin = Address::generate(&env);
         let new_admin = Address::generate(&env);
         let impostor = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.propose_admin(&admin, &new_admin);
 
         use soroban_sdk::IntoVal;
@@ -1196,7 +1197,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1223,7 +1224,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1252,7 +1253,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1276,7 +1277,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1306,7 +1307,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1356,7 +1357,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1381,7 +1382,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1410,7 +1411,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1439,7 +1440,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1464,7 +1465,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1487,7 +1488,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1522,7 +1523,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1553,7 +1554,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
         client.add_asset_type(&admin, &symbol_short!("TURBINE"));
 
@@ -1595,7 +1596,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1624,7 +1625,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1668,7 +1669,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1713,7 +1714,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1747,9 +1748,9 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         // Second call must panic
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
     }
 
     #[test]
@@ -1760,7 +1761,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1783,7 +1784,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1826,7 +1827,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1860,7 +1861,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1891,7 +1892,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1926,7 +1927,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1960,7 +1961,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -1999,7 +2000,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.pause(&admin);
 
         let events = env.events().all();
@@ -2020,7 +2021,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.pause(&admin);
         client.unpause(&admin);
 
@@ -2042,7 +2043,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2115,7 +2116,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2146,7 +2147,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2188,7 +2189,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         let owner = Address::generate(&env);
         client.batch_register_assets(&owner, &Vec::new(&env));
@@ -2205,7 +2206,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2248,7 +2249,7 @@ mod tests {
             let contract_id = env.register(AssetRegistry, ());
             let client = AssetRegistryClient::new(&env, &contract_id);
             let admin = Address::generate(&env);
-            client.initialize_admin(&admin);
+            client.initialize_admin(&admin, &admin);
             (contract_id, client, admin)
         };
 
@@ -2321,7 +2322,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("VALID"));
 
         let owner = Address::generate(&env);
@@ -2352,7 +2353,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2382,7 +2383,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2404,7 +2405,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2439,7 +2440,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2470,7 +2471,7 @@ mod tests {
         let contract_id = env.register(AssetRegistry, ());
         let client = AssetRegistryClient::new(&env, &contract_id);
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         assert_eq!(
             client.try_deregister_asset(&admin, &9999u64),
@@ -2488,7 +2489,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2524,7 +2525,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let events = env.events().all();
@@ -2549,7 +2550,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
         client.remove_asset_type(&admin, &symbol_short!("GENSET"));
 
@@ -2574,7 +2575,7 @@ mod tests {
         let admin = Address::generate(&env);
         let owner = Address::generate(&env);
         let client = AssetRegistryClient::new(&env, &env.register(AssetRegistry, ()));
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let result = client.try_register_asset(
@@ -2593,7 +2594,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2637,7 +2638,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         // Pause the contract
@@ -2680,7 +2681,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         // Simulate instance TTL expiry by wiping all instance storage
@@ -2705,7 +2706,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         env.as_contract(&contract_id, || {
@@ -2730,7 +2731,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         client.add_asset_type(&admin, &symbol_short!("GENSET"));
 
         let owner = Address::generate(&env);
@@ -2820,7 +2821,7 @@ mod tests {
         let client = AssetRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         // Verify instance TTL was extended after writing ADMIN_KEY
         env.as_contract(&contract_id, || {
@@ -2840,5 +2841,31 @@ mod tests {
 
         // get_admin must still resolve correctly (TTL was extended at init time)
         assert_eq!(client.get_admin(), admin);
+    }
+
+    #[test]
+    fn test_initialize_admin_rejects_non_deployer() {
+        let env = Env::default();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        // Authorize only the attacker, not the deployer.
+        use soroban_sdk::IntoVal;
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize_admin",
+                args: (&attacker, &attacker).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        // Passing attacker as deployer but deployer's auth is not present — must fail.
+        let result = client.try_initialize_admin(&deployer, &attacker);
+        assert!(result.is_err(), "non-deployer must not be able to initialize");
     }
 }

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -335,12 +335,13 @@ impl EngineerRegistry {
     /// This function should be called once immediately after deployment.
     ///
     /// # Arguments
+    /// * `deployer` - The address of the contract deployer; must sign this transaction.
     /// * `admin` - The address that will have administrative privileges
     ///
     /// # Panics
     /// - [`ContractError::AdminAlreadyInitialized`] if admin has already been initialized
-    pub fn initialize_admin(env: Env, admin: Address) {
-        admin.require_auth();
+    pub fn initialize_admin(env: Env, deployer: Address, admin: Address) {
+        deployer.require_auth();
         if env.storage().instance().has(&admin_key()) {
             panic_with_error!(&env, ContractError::AdminAlreadyInitialized);
         }
@@ -652,7 +653,7 @@ mod tests {
         let contract_id = env.register(EngineerRegistry, ());
         let client = EngineerRegistryClient::new(env, &contract_id);
         let admin = Address::generate(env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         (client, admin)
     }
 
@@ -665,9 +666,9 @@ mod tests {
         let client = EngineerRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
         // Second call must panic
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
     }
 
     #[test]
@@ -786,7 +787,7 @@ mod tests {
         let client = EngineerRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         // Second call should fail with structured error
         let result = client.try_initialize_admin(&admin);
@@ -807,7 +808,7 @@ mod tests {
 
         let admin = Address::generate(&env);
         // This should succeed because we mock all auths
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         // Verify admin was set
         assert_eq!(client.get_admin(), admin);
@@ -821,7 +822,7 @@ mod tests {
         let client = EngineerRegistryClient::new(&env, &contract_id);
 
         let admin = Address::generate(&env);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
         assert!(
@@ -1931,7 +1932,7 @@ mod tests {
                 sub_invokes: &[],
             },
         }]);
-        client.initialize_admin(&admin);
+        client.initialize_admin(&admin, &admin);
 
         // Add both issuers as trusted
         env.mock_auths(&[soroban_sdk::testutils::MockAuth {
@@ -2355,5 +2356,29 @@ mod tests {
                 ContractError::Paused as u32
             )))
         );
+    }
+
+    #[test]
+    fn test_initialize_admin_rejects_non_deployer() {
+        let env = Env::default();
+        let contract_id = env.register(EngineerRegistry, ());
+        let client = EngineerRegistryClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        use soroban_sdk::IntoVal;
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize_admin",
+                args: (&attacker, &attacker).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        let result = client.try_initialize_admin(&deployer, &attacker);
+        assert!(result.is_err(), "non-deployer must not be able to initialize");
     }
 }

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -387,6 +387,7 @@ impl Lifecycle {
     /// # Arguments
     /// * `asset_registry` - Address of the asset registry contract
     /// * `engineer_registry` - Address of the engineer registry contract
+    /// * `deployer` - The address of the contract deployer; must sign this transaction.
     /// * `admin` - Address that will have administrative privileges
     /// * `max_history` - Maximum maintenance records per asset (0 for default 200)
     ///
@@ -394,11 +395,13 @@ impl Lifecycle {
     /// - [`ContractError::AlreadyInitialized`] if contract has already been initialized
     pub fn initialize(
         env: Env,
+        deployer: Address,
         asset_registry: Address,
         engineer_registry: Address,
         admin: Address,
         max_history: u32,
     ) {
+        deployer.require_auth();
         if env.storage().persistent().has(&CONFIG) {
             panic_with_error!(&env, ContractError::AlreadyInitialized);
         }
@@ -1730,6 +1733,7 @@ mod tests {
 
         let lifecycle = LifecycleClient::new(env, &lifecycle_id);
         lifecycle.initialize(
+            &admin,
             &asset_registry_id,
             &engineer_registry_id,
             &admin,
@@ -1737,7 +1741,7 @@ mod tests {
         );
 
         let asset_registry = AssetRegistryClient::new(env, &asset_registry_id);
-        asset_registry.initialize_admin(&asset_admin);
+        asset_registry.initialize_admin(&asset_admin, &asset_admin);
         asset_registry.add_asset_type(&asset_admin, &symbol_short!("GENSET"));
 
         (
@@ -1762,7 +1766,7 @@ mod tests {
         let issuer = Address::generate(env);
         let admin = Address::generate(env);
         let hash = BytesN::from_array(env, &[1u8; 32]);
-        registry_client.initialize_admin(&admin);
+        registry_client.initialize_admin(&admin, &admin);
         registry_client.add_trusted_issuer(&admin, &issuer);
         registry_client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
         engineer
@@ -2878,7 +2882,7 @@ mod tests {
         let admin = Address::generate(&env);
 
         let lifecycle = LifecycleClient::new(&env, &lifecycle_id);
-        lifecycle.initialize(&asset_registry_id, &engineer_registry_id, &admin, &0u32);
+        lifecycle.initialize(&admin, &asset_registry_id, &engineer_registry_id, &admin, &0u32);
 
         let events = env.events().all();
         assert_eq!(events.len(), 1);
@@ -2895,7 +2899,7 @@ mod tests {
         let admin = Address::generate(&env);
 
         let lifecycle = LifecycleClient::new(&env, &lifecycle_id);
-        lifecycle.initialize(&asset_registry_id, &engineer_registry_id, &admin, &0u32);
+        lifecycle.initialize(&admin, &asset_registry_id, &engineer_registry_id, &admin, &0u32);
 
         // Try to initialize again
         let result =
@@ -3995,7 +3999,7 @@ mod tests {
         let admin = Address::generate(&env);
         let hash_v1 = BytesN::from_array(&env, &[1u8; 32]);
 
-        engineer_registry_client.initialize_admin(&admin);
+        engineer_registry_client.initialize_admin(&admin, &admin);
         engineer_registry_client.add_trusted_issuer(&admin, &issuer);
         engineer_registry_client.register_engineer(&engineer, &hash_v1, &issuer, &31_536_000);
 
@@ -4048,7 +4052,7 @@ mod tests {
         let issuer = Address::generate(&env);
         let admin = Address::generate(&env);
         let hash = BytesN::from_array(&env, &[1u8; 32]);
-        engineer_registry_client.initialize_admin(&admin);
+        engineer_registry_client.initialize_admin(&admin, &admin);
         engineer_registry_client.add_trusted_issuer(&admin, &issuer);
         engineer_registry_client.register_engineer(&engineer, &hash, &issuer, &1000);
 
@@ -4096,7 +4100,7 @@ mod tests {
         let issuer = Address::generate(&env);
         let eng_admin = Address::generate(&env);
         let hash = BytesN::from_array(&env, &[1u8; 32]);
-        engineer_registry_client.initialize_admin(&eng_admin);
+        engineer_registry_client.initialize_admin(&eng_admin, &eng_admin);
         engineer_registry_client.add_trusted_issuer(&eng_admin, &issuer);
         // Register with validity_period = 100 seconds
         engineer_registry_client.register_engineer(&engineer, &hash, &issuer, &100);
@@ -4141,7 +4145,7 @@ mod tests {
         let issuer = Address::generate(&env);
         let eng_admin = Address::generate(&env);
         let hash = BytesN::from_array(&env, &[1u8; 32]);
-        engineer_registry_client.initialize_admin(&eng_admin);
+        engineer_registry_client.initialize_admin(&eng_admin, &eng_admin);
         engineer_registry_client.add_trusted_issuer(&eng_admin, &issuer);
         // Register with validity_period = 100 seconds
         engineer_registry_client.register_engineer(&engineer, &hash, &issuer, &100);
@@ -4191,7 +4195,7 @@ mod tests {
         let engineer = Address::generate(&env);
         let issuer = Address::generate(&env);
         let admin = Address::generate(&env);
-        engineer_registry.initialize_admin(&admin);
+        engineer_registry.initialize_admin(&admin, &admin);
         engineer_registry.add_trusted_issuer(&admin, &issuer);
         engineer_registry.register_engineer(
             &engineer,
@@ -4619,7 +4623,7 @@ mod tests {
         let admin = Address::generate(&env);
 
         let lifecycle = LifecycleClient::new(&env, &lifecycle_id);
-        lifecycle.initialize(&asset_registry_id, &engineer_registry_id, &admin, &0u32);
+        lifecycle.initialize(&admin, &asset_registry_id, &engineer_registry_id, &admin, &0u32);
 
         // Verify registries are accessible normally
         assert_eq!(lifecycle.get_asset_registry(), asset_registry_id);
@@ -5387,7 +5391,7 @@ mod tests {
         let admin = Address::generate(&env);
 
         let client = LifecycleClient::new(&env, &lifecycle_id);
-        client.initialize(&asset_registry_id, &engineer_registry_id, &admin, &0u32);
+        client.initialize(&admin, &asset_registry_id, &engineer_registry_id, &admin, &0u32);
 
         // Pause the contract
         client.pause(&admin);
@@ -5508,7 +5512,7 @@ mod tests {
         let engineer = Address::generate(&env);
         let issuer = Address::generate(&env);
         let eng_admin = Address::generate(&env);
-        engineer_registry.initialize_admin(&eng_admin);
+        engineer_registry.initialize_admin(&eng_admin, &eng_admin);
         engineer_registry.add_trusted_issuer(&eng_admin, &issuer);
         engineer_registry.register_engineer(
             &engineer,
@@ -5579,7 +5583,7 @@ mod tests {
         let engineer = Address::generate(&env);
         let eng_admin = Address::generate(&env);
 
-        engineer_registry.initialize_admin(&eng_admin);
+        engineer_registry.initialize_admin(&eng_admin, &eng_admin);
         engineer_registry.add_trusted_issuer(&eng_admin, &issuer);
         let asset_id = asset_registry.register_asset(
             &symbol_short!("GENSET"),
@@ -5641,7 +5645,7 @@ mod tests {
         let engineer = Address::generate(&env);
         let eng_admin = Address::generate(&env);
 
-        engineer_registry.initialize_admin(&eng_admin);
+        engineer_registry.initialize_admin(&eng_admin, &eng_admin);
         engineer_registry.add_trusted_issuer(&eng_admin, &issuer);
         let asset_id = asset_registry.register_asset(
             &symbol_short!("GENSET"),
@@ -5849,5 +5853,31 @@ mod tests {
         // BUG: Currently, asset_id is STILL in engineer's history
         let history_after = lifecycle.get_eng_history_page(&engineer, &0, &10);
         assert!(!history_after.contains(asset_id), "Asset ID should be removed from engineer history after purge");
+    }
+
+    #[test]
+    fn test_initialize_rejects_non_deployer() {
+        let env = Env::default();
+        let asset_registry_id = env.register(AssetRegistry, ());
+        let engineer_registry_id = env.register(EngineerRegistry, ());
+        let lifecycle_id = env.register(Lifecycle, ());
+        let client = LifecycleClient::new(&env, &lifecycle_id);
+
+        let deployer = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        use soroban_sdk::IntoVal;
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &attacker,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &lifecycle_id,
+                fn_name: "initialize",
+                args: (&attacker, &asset_registry_id, &engineer_registry_id, &attacker, &0u32).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+
+        let result = client.try_initialize(&deployer, &asset_registry_id, &engineer_registry_id, &attacker, &0u32);
+        assert!(result.is_err(), "non-deployer must not be able to initialize");
     }
 }

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -37,20 +37,32 @@ stellar contract deploy --wasm target/wasm32-unknown-unknown/release/lifecycle.w
 
 ## 3. Initialization & TTL Setup
 
+> **Security: deployer-only initialization**
+> Each `initialize_admin` / `initialize` call now requires the `deployer` argument to sign the
+> transaction. The `--source deployer` flag on the Stellar CLI satisfies this requirement.
+> **Complete all three initialization steps in the same block as deployment** (or immediately
+> after) to eliminate the window in which an observer could front-run initialization with their
+> own address.
+
 ### 3.1 Initialize Asset Registry Admin
 ```bash
-stellar contract invoke --id AR_ID --network testnet --source deployer -- initialize_admin --admin <ADMIN_ADDRESS>
+stellar contract invoke --id AR_ID --network testnet --source deployer -- initialize_admin \
+  --deployer <DEPLOYER_ADDRESS> \
+  --admin <ADMIN_ADDRESS>
 ```
 
 ### 3.2 Initialize Engineer Registry Admin
 ```bash
-stellar contract invoke --id ER_ID --network testnet --source deployer -- initialize_admin --admin <ADMIN_ADDRESS>
+stellar contract invoke --id ER_ID --network testnet --source deployer -- initialize_admin \
+  --deployer <DEPLOYER_ADDRESS> \
+  --admin <ADMIN_ADDRESS>
 ```
 
 ### 3.3 Initialize Lifecycle Binding
 Connect Lifecycle to AR and ER:
 ```bash
 stellar contract invoke --id LC_ID --network testnet --source deployer -- initialize \
+  --deployer <DEPLOYER_ADDRESS> \
   --asset_registry AR_ID \
   --engineer_registry ER_ID \
   --admin <ADMIN_ADDRESS> \


### PR DESCRIPTION
Closes #565

---

## Problem

Any address could call `initialize_admin` / `initialize` before the deployer completed initialization. The functions only called `admin.require_auth()`, so an observer watching the deployment transaction could front-run it and seize admin.

## Changes

**Contracts** — all three contracts:
- Added `deployer: Address` as the first parameter to `initialize_admin` (asset-registry, engineer-registry) and `initialize` (lifecycle)
- Added `deployer.require_auth()` as the first statement, so the transaction must be signed by the deployer

**Tests:**
- Updated all existing call sites to pass `deployer` as first argument
- Added `test_initialize_admin_rejects_non_deployer` to asset-registry and engineer-registry
- Added `test_initialize_rejects_non_deployer` to lifecycle
- Each new test uses `mock_auths` to authorize only an attacker address, then asserts `try_initialize*` returns an error when called with the real deployer (whose auth is absent)

**Docs:**
- Updated `docs/deployment-runbook.md` section 3 with a security callout and `--deployer` flag in all CLI invocation examples

## Testing

All existing tests updated. Three new unauthorized-init tests added, one per contract.