### PR TITLE
fix: add minimum score floor for assets with maintenance history

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -72,6 +72,10 @@ const DEFAULT_DECAY_RATE: u32 = 5;
 const DEFAULT_DECAY_INTERVAL: u64 = 2592000; // 30 days in seconds
 const DEFAULT_ELIGIBILITY_THRESHOLD: u32 = 50;
 const DEFAULT_MAX_NOTES_LENGTH: u32 = 256;
+/// Minimum score returned for an asset that has at least one maintenance record.
+/// Prevents decay from making a legitimately-maintained asset indistinguishable
+/// from one with no history at all.
+const MIN_SCORE_WITH_HISTORY: u32 = 1;
 
 const EVENT_INIT: Symbol = symbol_short!("INIT");
 const EVENT_MAINT: Symbol = symbol_short!("MAINT");
@@ -1179,7 +1183,20 @@ impl Lifecycle {
             .persistent()
             .get::<_, Config>(&CONFIG)
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
-        compute_decay(&env, asset_id)
+        let score = compute_decay(&env, asset_id);
+        // Apply floor: an asset with at least one maintenance record always scores >= 1
+        // so it is never indistinguishable from an asset with no history.
+        let has_history = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<MaintenanceRecord>>(&history_key(asset_id))
+            .map(|h| !h.is_empty())
+            .unwrap_or(false);
+        if has_history && score < MIN_SCORE_WITH_HISTORY {
+            MIN_SCORE_WITH_HISTORY
+        } else {
+            score
+        }
     }
 
     /// Returns the full score trend: one (timestamp, score) entry per maintenance event.
@@ -1265,7 +1282,19 @@ impl Lifecycle {
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
 
         // Use read-only decay computation since we already verified asset exists
-        compute_decay(&env, asset_id) >= config.eligibility_threshold
+        let score = compute_decay(&env, asset_id);
+        let has_history = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<MaintenanceRecord>>(&history_key(asset_id))
+            .map(|h| !h.is_empty())
+            .unwrap_or(false);
+        let effective_score = if has_history && score < MIN_SCORE_WITH_HISTORY {
+            MIN_SCORE_WITH_HISTORY
+        } else {
+            score
+        };
+        effective_score >= config.eligibility_threshold
     }
 
     /// Returns the timestamp of the most recent maintenance event, or None if no maintenance has been submitted.
@@ -5849,5 +5878,39 @@ mod tests {
         // BUG: Currently, asset_id is STILL in engineer's history
         let history_after = lifecycle.get_eng_history_page(&engineer, &0, &10);
         assert!(!history_after.contains(asset_id), "Asset ID should be removed from engineer history after purge");
+    }
+
+    /// An asset with a single maintenance record must never score 0, even after enough
+    /// time has elapsed for decay to fully consume the raw score.
+    #[test]
+    fn test_score_floor_with_sparse_history() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let asset_id = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+
+        // One record → raw score = DEFAULT_SCORE_INCREMENT (5)
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "single record"),
+            &engineer,
+        );
+        assert_eq!(client.get_collateral_score(&asset_id), 5);
+
+        // Advance time by 2 full decay intervals (2 × 30 days).
+        // Decay = 2 × DEFAULT_DECAY_RATE (5) = 10 > raw score (5), so raw result = 0.
+        env.ledger().with_mut(|li| {
+            li.timestamp += 2 * 2_592_000; // 60 days
+        });
+
+        // Floor must kick in: score is 1, not 0.
+        assert_eq!(
+            client.get_collateral_score(&asset_id),
+            1,
+            "asset with maintenance history must not score 0 after decay"
+        );
     }
 }

--- a/docs/collateral-scoring.md
+++ b/docs/collateral-scoring.md
@@ -6,10 +6,30 @@ This document describes the collateral scoring model used in the Mainstay lifecy
 
 The collateral scoring system is designed to provide a quantitative measure of an asset's maintenance quality and recency. Higher scores indicate well-maintained assets that are more suitable for use as collateral in financial transactions.
 
+## Score Floor
+
+Assets with at least one verified maintenance record are guaranteed a minimum score of **1** (`MIN_SCORE_WITH_HISTORY`), even if time-based decay would otherwise reduce the raw score to 0.
+
+This prevents a legitimately-maintained asset from becoming indistinguishable from one with no history at all.
+
+| Maintenance records | Minimum score returned |
+|---------------------|------------------------|
+| 0                   | 0                      |
+| ≥ 1                 | 1 (floor)              |
+
+### Minimum records for non-zero score
+
+With default configuration (`score_increment = 5`):
+
+- **1 record** → raw score = 5 (non-zero immediately after submission)
+- After sufficient decay the raw score reaches 0, but the floor ensures `get_collateral_score` returns **1**
+
+To reach the default **eligibility threshold of 50**, an asset needs at least **10 records** at the default increment of 5 points each (or fewer records using higher-weight task types such as `ENGINE` / `OVERHAUL` at 10 points each).
+
 ## Score Mechanics
 
 ### Score Range
-- **Minimum Score**: 0 points
+- **Minimum Score**: 0 points (no maintenance history), or **1 point** (at least one record — see [Score Floor](#score-floor))
 - **Maximum Score**: 100 points
 - **Eligibility Threshold**: 50 points (default, configurable)
 


### PR DESCRIPTION
Closes #564

---

## Problem

Integer division in the decay calculation can reduce a legitimately-maintained asset's collateral score to 0. With default config (`score_increment=5`, `decay_rate=5`), a single maintenance record gives a raw score of 5. After 2 decay intervals (60 days) the decay (10) exceeds the raw score, returning 0 — making the asset indistinguishable from one with no maintenance history at all.

## Changes

**`contracts/lifecycle/src/lib.rs`**
- Added `MIN_SCORE_WITH_HISTORY = 1` constant
- Applied floor in `get_collateral_score`: if asset has ≥1 maintenance record and decayed score < 1, return 1
- Applied same floor in `is_collateral_eligible` for consistency
- Added `test_score_floor_with_sparse_history`: submits 1 record (score=5), advances 60 days (decay=10 > score, raw=0), asserts `get_collateral_score` returns 1

**`docs/collateral-scoring.md`**
- Updated Score Range to document the floor
- Added Score Floor section with table and minimum record count explanation
- Documents that 10 records at default increment (or fewer with higher-weight tasks) are needed to reach the 50-point eligibility threshold