### PR TITLE
fix: extend instance TTL in all admin-mutating functions

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -441,6 +441,7 @@ impl AssetRegistry {
             panic_with_error!(&env, ContractError::PendingAdminAlreadyExists);
         }
         env.storage().instance().set(&PENDING_ADMIN_KEY, &new_admin);
+        env.storage().instance().extend_ttl(518400, 518400);
         env.events()
             .publish((symbol_short!("PROP_ADM"),), (admin, new_admin));
     }
@@ -466,6 +467,7 @@ impl AssetRegistry {
         }
         env.storage().instance().set(&ADMIN_KEY, &pending_admin);
         env.storage().instance().remove(&PENDING_ADMIN_KEY);
+        env.storage().instance().extend_ttl(518400, 518400);
         env.events()
             .publish((symbol_short!("ADMIN_SET"),), (pending_admin,));
     }
@@ -484,6 +486,7 @@ impl AssetRegistry {
         env.storage()
             .persistent()
             .extend_ttl(&PAUSED_KEY, 518400, 518400);
+        env.storage().instance().extend_ttl(518400, 518400);
         env.events().publish((symbol_short!("PAUSED"),), (admin,));
     }
 
@@ -501,6 +504,7 @@ impl AssetRegistry {
         env.storage()
             .persistent()
             .extend_ttl(&PAUSED_KEY, 518400, 518400);
+        env.storage().instance().extend_ttl(518400, 518400);
         env.events().publish((symbol_short!("UNPAUSED"),), (admin,));
     }
 
@@ -721,6 +725,8 @@ impl AssetRegistry {
         if stored_admin != admin {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
+
+        env.storage().instance().extend_ttl(518400, 518400);
 
         #[cfg(not(test))]
         {
@@ -2668,6 +2674,139 @@ mod tests {
                 ContractError::Paused as u32
             )))
         );
+    }
+
+    // --- Instance TTL expiry tests ---
+
+    /// Helper: wipe instance storage to simulate TTL expiry.
+    fn wipe_instance(env: &Env, contract_id: &Address) {
+        env.as_contract(contract_id, || {
+            env.storage().instance().remove(&ADMIN_KEY);
+            env.storage().instance().remove(&PENDING_ADMIN_KEY);
+        });
+    }
+
+    #[test]
+    fn test_pause_extends_instance_ttl_after_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        // Simulate expiry then re-init
+        client.initialize_admin(&admin);
+        wipe_instance(&env, &contract_id);
+        client.initialize_admin(&admin);
+
+        client.pause(&admin);
+        let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "pause must extend instance TTL");
+    }
+
+    #[test]
+    fn test_unpause_extends_instance_ttl_after_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin);
+        client.pause(&admin);
+        wipe_instance(&env, &contract_id);
+        client.initialize_admin(&admin);
+
+        client.unpause(&admin);
+        let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "unpause must extend instance TTL");
+    }
+
+    #[test]
+    fn test_propose_admin_extends_instance_ttl_after_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin);
+        wipe_instance(&env, &contract_id);
+        client.initialize_admin(&admin);
+
+        let new_admin = Address::generate(&env);
+        client.propose_admin(&admin, &new_admin);
+        let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "propose_admin must extend instance TTL");
+    }
+
+    #[test]
+    fn test_accept_admin_extends_instance_ttl_after_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+        client.initialize_admin(&admin);
+        client.propose_admin(&admin, &new_admin);
+
+        // Simulate partial expiry (keep admin + pending_admin intact)
+        // accept_admin reads PENDING_ADMIN_KEY which must still be present
+        client.accept_admin(&new_admin);
+        assert_eq!(client.get_admin(), new_admin);
+        let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "accept_admin must extend instance TTL");
+    }
+
+    #[test]
+    fn test_upgrade_extends_instance_ttl_after_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin);
+        wipe_instance(&env, &contract_id);
+        client.initialize_admin(&admin);
+
+        let hash = BytesN::from_array(&env, &[0xabu8; 32]);
+        client.upgrade(&admin, &hash);
+        let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "upgrade must extend instance TTL");
+    }
+
+    #[test]
+    fn test_admin_ops_work_after_instance_ttl_expiry_and_reinit() {
+        // Full scenario: instance expires, admin re-initializes, all ops succeed.
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin);
+        client.add_asset_type(&admin, &symbol_short!("GENSET"));
+
+        // Simulate instance TTL expiry
+        wipe_instance(&env, &contract_id);
+
+        // Re-initialize admin
+        client.initialize_admin(&admin);
+
+        // All admin ops must succeed and extend TTL
+        client.pause(&admin);
+        client.unpause(&admin);
+
+        let new_admin = Address::generate(&env);
+        client.propose_admin(&admin, &new_admin);
+        client.accept_admin(&new_admin);
+        assert_eq!(client.get_admin(), new_admin);
+
+        let ttl = env.as_contract(&contract_id, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "instance TTL must be live after admin ops");
     }
 
     // --- Issue #381: is_valid_asset_type survives instance TTL expiry ---

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -384,6 +384,7 @@ impl EngineerRegistry {
         env.storage()
             .instance()
             .set(&pending_admin_key(), &new_admin);
+        env.storage().instance().extend_ttl(518400, 518400);
         env.events()
             .publish((EVENT_PROP_ADMIN,), (admin, new_admin));
     }
@@ -403,6 +404,7 @@ impl EngineerRegistry {
         pending_admin.require_auth();
         env.storage().instance().set(&admin_key(), &pending_admin);
         env.storage().instance().remove(&pending_admin_key());
+        env.storage().instance().extend_ttl(518400, 518400);
         env.events()
             .publish((symbol_short!("ADMIN_SET"),), (pending_admin,));
     }
@@ -421,6 +423,7 @@ impl EngineerRegistry {
         env.storage()
             .persistent()
             .extend_ttl(&PAUSED_KEY, 518400, 518400);
+        env.storage().instance().extend_ttl(518400, 518400);
         env.events().publish((symbol_short!("PAUSED"),), (admin,));
     }
 
@@ -438,6 +441,7 @@ impl EngineerRegistry {
         env.storage()
             .persistent()
             .extend_ttl(&PAUSED_KEY, 518400, 518400);
+        env.storage().instance().extend_ttl(518400, 518400);
         env.events().publish((symbol_short!("UNPAUSED"),), (admin,));
     }
 
@@ -624,6 +628,8 @@ impl EngineerRegistry {
         if stored_admin != admin {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
+
+        env.storage().instance().extend_ttl(518400, 518400);
 
         env.events().publish(
             (symbol_short!("UPGRADE"), admin.clone()),
@@ -2355,5 +2361,130 @@ mod tests {
                 ContractError::Paused as u32
             )))
         );
+    }
+
+    // --- Instance TTL expiry tests ---
+
+    /// Helper: wipe all instance storage to simulate TTL expiry.
+    fn wipe_instance(env: &Env, contract_id: &Address) {
+        env.as_contract(contract_id, || {
+            env.storage().instance().remove(&admin_key());
+            env.storage().instance().remove(&pending_admin_key());
+            env.storage().instance().remove(&issuer_list_key());
+        });
+    }
+
+    #[test]
+    fn test_pause_extends_instance_ttl_after_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        // Simulate instance TTL expiry — admin key is gone
+        wipe_instance(&env, &client.address);
+
+        // Re-initialize so pause can read the admin
+        client.initialize_admin(&admin);
+
+        // pause must extend instance TTL
+        client.pause(&admin);
+        let ttl = env.as_contract(&client.address, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "pause must extend instance TTL");
+    }
+
+    #[test]
+    fn test_unpause_extends_instance_ttl_after_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        client.pause(&admin);
+        wipe_instance(&env, &client.address);
+        client.initialize_admin(&admin);
+
+        client.unpause(&admin);
+        let ttl = env.as_contract(&client.address, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "unpause must extend instance TTL");
+    }
+
+    #[test]
+    fn test_propose_admin_extends_instance_ttl_after_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        wipe_instance(&env, &client.address);
+        client.initialize_admin(&admin);
+
+        let new_admin = Address::generate(&env);
+        client.propose_admin(&admin, &new_admin);
+        let ttl = env.as_contract(&client.address, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "propose_admin must extend instance TTL");
+    }
+
+    #[test]
+    fn test_accept_admin_extends_instance_ttl_after_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let new_admin = Address::generate(&env);
+        client.propose_admin(&admin, &new_admin);
+
+        // Wipe instance storage (simulates TTL expiry between propose and accept)
+        // We must restore admin + pending_admin so accept_admin can read them
+        env.as_contract(&client.address, || {
+            // Keep admin and pending_admin but clear issuer_list to simulate partial expiry
+            env.storage().instance().remove(&issuer_list_key());
+        });
+
+        client.accept_admin();
+        assert_eq!(client.get_admin(), new_admin);
+        let ttl = env.as_contract(&client.address, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "accept_admin must extend instance TTL");
+    }
+
+    #[test]
+    fn test_upgrade_extends_instance_ttl_after_expiry() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        wipe_instance(&env, &client.address);
+        client.initialize_admin(&admin);
+
+        let hash = BytesN::from_array(&env, &[0xabu8; 32]);
+        client.upgrade(&admin, &hash);
+        let ttl = env.as_contract(&client.address, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "upgrade must extend instance TTL");
+    }
+
+    #[test]
+    fn test_admin_ops_work_after_instance_ttl_expiry_and_reinit() {
+        // Full scenario: instance expires, admin re-initializes, all ops succeed.
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let issuer = Address::generate(&env);
+        client.add_trusted_issuer(&admin, &issuer);
+
+        // Simulate instance TTL expiry
+        wipe_instance(&env, &client.address);
+
+        // Re-initialize admin (as would happen after TTL expiry recovery)
+        client.initialize_admin(&admin);
+
+        // All admin ops must succeed and extend TTL
+        client.pause(&admin);
+        client.unpause(&admin);
+
+        let new_admin = Address::generate(&env);
+        client.propose_admin(&admin, &new_admin);
+        client.accept_admin();
+        assert_eq!(client.get_admin(), new_admin);
+
+        let ttl = env.as_contract(&client.address, || env.storage().instance().get_ttl());
+        assert!(ttl > 0, "instance TTL must be live after admin ops");
     }
 }

--- a/docs/ttl-strategy.md
+++ b/docs/ttl-strategy.md
@@ -4,7 +4,7 @@ Soroban persistent storage entries expire if their Time-To-Live (TTL) is not ext
 
 ## Storage Types
 
-- **Instance Storage**: Used for shared contract configuration (admin address, registry bindings, etc.). Instance storage is automatically extended when the contract is called, but should still be managed for longevity.
+- **Instance Storage**: Used for shared contract configuration (admin address, trusted issuers, registry bindings, etc.). Instance storage TTL is **not** automatically extended on every call — it must be explicitly extended on every write to prevent the admin address and other critical config from expiring.
 - **Persistent Storage**: Used for all asset-specific data, maintenance records, and scores. **Requires explicit extension** to ensure longevity.
 
 ## TTL Parameters
@@ -21,16 +21,25 @@ Mainstay uses a standardized 30-day extension policy:
 | ----------- | ------------ | ----------- |
 | `(Symbol("ASSET"), id: u64)` | Persistent | Full `Asset` record (metadata, owner, etc.) |
 | `(Symbol("DEDUP"), owner: Address, hash: BytesN<32>)` | Persistent | Mapping of unique metadata to active asset IDs |
-| `Symbol("A_COUNT")` | Instance | Global counter for total registered assets |
-| `Symbol("ADMIN")` | Instance | Admin address authorized for deregistration |
+| `Symbol("A_COUNT")` | Persistent | Global counter for total registered assets |
+| `Symbol("PAUSED")` | Persistent | Contract pause flag |
+| `Symbol("ADMIN")` | Instance | Admin address authorized for admin operations |
+| `Symbol("PADMIN")` | Instance | Pending admin address during 2-step transfer |
+| `(Symbol("AST_TYPE"), asset_type: Symbol)` | Persistent | Asset type allowlist entries |
+| `(Symbol("AST_CNT"), asset_type: Symbol)` | Instance | Per-type asset count (for TypeInUse guard) |
+| `(Symbol("OWN_IDX"), owner: Address)` | Persistent | Owner → Vec<asset_id> index |
 
 ### 2. Engineer Registry
 
 | Key Pattern | Storage Type | Description |
 | ----------- | ------------ | ----------- |
 | `(Symbol("ENG"), addr: Address)` | Persistent | `Engineer` record (credential hash, active status) |
+| `(Symbol("ISS_ENGS"), issuer: Address)` | Persistent | Issuer → Vec<engineer_address> mapping |
+| `Symbol("PAUSED")` | Persistent | Contract pause flag |
 | `(Symbol("TRUSTED"), issuer: Address)` | Instance | Registry of trusted credential issuers |
+| `Symbol("ISS_LIST")` | Instance | Authoritative list of all trusted issuer addresses |
 | `Symbol("ADMIN")` | Instance | Admin address authorized for trust management |
+| `Symbol("PADMIN")` | Instance | Pending admin address during 2-step transfer |
 
 ### 3. Lifecycle Contract
 
@@ -45,13 +54,51 @@ Mainstay uses a standardized 30-day extension policy:
 
 ## Extension Logic
 
-- **Automatic Extension**: All `persistent` entries should be extended upon every `set` operation.
-- **Manual Extension**: Use the Soroban CLI to extend entries if they are near expiration but no write operations are expected.
+### Instance Storage
+
+Instance storage holds the admin address and other critical configuration. If it expires, all admin-gated operations (`pause`, `unpause`, `propose_admin`, `accept_admin`, `upgrade`, `add_trusted_issuer`, `remove_trusted_issuer`) will panic with `NotInitialized`.
+
+To prevent this, **every admin-mutating function** calls `env.storage().instance().extend_ttl(518400, 518400)` after its writes. This ensures the instance TTL is refreshed on every admin interaction, keeping it alive as long as the contract is actively administered.
+
+Functions that extend instance TTL in **AssetRegistry**:
+- `initialize_admin`
+- `propose_admin`
+- `accept_admin`
+- `pause`
+- `unpause`
+- `upgrade`
+
+Functions that extend instance TTL in **EngineerRegistry**:
+- `initialize_admin`
+- `propose_admin`
+- `accept_admin`
+- `pause`
+- `unpause`
+- `upgrade`
+- `add_trusted_issuer`
+- `remove_trusted_issuer`
+
+### Persistent Storage
+
+All `persistent` entries are extended upon every `set` operation using `extend_ttl(518400, 518400)`.
+
+### Manual Extension
+
+Use the Soroban CLI to extend entries if they are near expiration but no write operations are expected:
 
 ```bash
-# Example manual extension
 stellar contract storage extend --id <CONTRACT_ID> \
   --key '<KEY_XDR>' \
   --durability persistent \
   --ledgers-to-extend 518400
 ```
+
+## Why Instance TTL Matters
+
+Instance storage is **not** automatically extended on every contract invocation. If the instance TTL expires:
+
+- `get_admin` panics with `NotInitialized`, locking out all admin operations
+- Trusted issuer lookups return empty, blocking engineer registration
+- The contract becomes unrecoverable without re-deploying
+
+The fix is to call `env.storage().instance().extend_ttl(518400, 518400)` in every function that writes to instance storage, ensuring the TTL is refreshed on every admin interaction.


### PR DESCRIPTION
Closes #540

---

## Summary

Instance storage holds the admin address and trusted-issuer list. If its TTL expires, `get_admin` panics with `NotInitialized`, locking out all admin operations (`pause`, `unpause`, `propose_admin`, `accept_admin`, `upgrade`, `add_trusted_issuer`, `remove_trusted_issuer`).

## Changes

**EngineerRegistry & AssetRegistry** — added `env.storage().instance().extend_ttl(518400, 518400)` to:
- `propose_admin`
- `accept_admin`
- `pause`
- `unpause`
- `upgrade`

(`add_trusted_issuer` and `remove_trusted_issuer` in EngineerRegistry already extended TTL.)

**Tests** — added 6 new tests per contract simulating instance TTL expiry:
- `test_pause_extends_instance_ttl_after_expiry`
- `test_unpause_extends_instance_ttl_after_expiry`
- `test_propose_admin_extends_instance_ttl_after_expiry`
- `test_accept_admin_extends_instance_ttl_after_expiry`
- `test_upgrade_extends_instance_ttl_after_expiry`
- `test_admin_ops_work_after_instance_ttl_expiry_and_reinit`

**Docs** — updated `docs/ttl-strategy.md` with the full instance storage TTL extension strategy and list of protected functions.

## Test Results

- asset-registry: 75 passed, 0 failed, 1 ignored
- engineer-registry: 76 passed, 0 failed, 1 ignored