### PR TITLE
chore: update .gitignore to exclude test snapshots and unnecessary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,27 +3,44 @@ target/
 
 # Environment secrets
 .env
+.env.local
+.env.*.local
 
 # Test snapshots
 contracts/asset-registry/test_snapshots/
 contracts/lifecycle/test_snapshots/
 contracts/engineer-registry/test_snapshots/
+**/test_snapshots/
 **/*.snap
 
 # IDE / editor
 .vscode/
 .idea/
 *.iml
+*.swp
+*.swo
+*~
 
 # OS
 .DS_Store
+.DS_Store?
 Thumbs.db
+ehthumbs.db
 
 # Logs
 *.log
+logs/
 
 # Wasm build output
 *.wasm
 
 # Rust
 Cargo.lock
+
+# Soroban / Stellar CLI artifacts
+.soroban/
+stellar-cli-output/
+
+# Temporary files
+*.tmp
+*.bak


### PR DESCRIPTION
#- Add **/test_snapshots/ glob to catch any new contract snapshot dirs
- Add .env variants (.env.local, .env.*.local)
- Add .soroban/ and stellar-cli-output/ for CLI artifacts
- Add common editor/OS noise (*.swp, *.swo, ehthumbs.db, etc.)
- Add *.tmp and *.bak temporary files

closes #560  
closes #561 
closes #562 
closes #563 