### PR TITLE
fix: get_maintenance_history panics with lifecycle's own AssetNotFound

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -1407,7 +1407,7 @@ impl Lifecycle {
     /// - [`ContractError::AssetNotFound`] if no asset exists with the given ID
     pub fn get_maintenance_history(env: Env, asset_id: u64) -> Vec<MaintenanceRecord> {
         let asset_registry = get_asset_registry_addr(&env);
-        asset_registry::AssetRegistryClient::new(&env, &asset_registry).get_asset(&asset_id);
+        verify_asset_exists(&env, &asset_registry, &asset_id);
         env.storage()
             .persistent()
             .get(&history_key(asset_id))
@@ -2319,7 +2319,7 @@ mod tests {
         assert_eq!(
             result,
             Err(Ok(soroban_sdk::Error::from_contract_error(
-                asset_registry::ContractError::AssetNotFound as u32,
+                ContractError::AssetNotFound as u32,
             ))),
         );
     }


### PR DESCRIPTION
## Summary

- `get_maintenance_history` was calling `get_asset` directly on the asset-registry client, bubbling up `asset_registry::ContractError::AssetNotFound` (error code `1`) instead of the lifecycle contract's own `ContractError::AssetNotFound` (error code `5`)
- Callers could not distinguish an unregistered asset from one with an empty maintenance history — both returned an empty `Vec`
- Replaced the direct `get_asset` call with `verify_asset_exists` — the same pattern used by all other functions in the contract (`get_maintenance_history_page`, `submit_maintenance`, etc.)
- Updated the existing test assertion to expect the correct lifecycle error code

## Test plan

- [ ] `test_get_maintenance_history_nonexistent_asset_returns_error` — verifies that querying an unregistered asset ID returns `ContractError::AssetNotFound` (lifecycle error code 5, not asset-registry code 1)
- [ ] Existing tests for registered assets with records remain unaffected

closes #566 