### PR TITLE
feat: resolve issues #815 #816 #817 #818

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ contracts/engineer-registry/test_snapshots/
 .DS_Store?
 Thumbs.db
 ehthumbs.db
+desktop.ini
 
 # Logs
 *.log
@@ -33,6 +34,11 @@ logs/
 
 # Wasm build output
 *.wasm
+contracts/*/target/
+
+# Rust incremental compilation cache
+**/*.d
+**/incremental/
 
 # Rust
 Cargo.lock
@@ -40,7 +46,18 @@ Cargo.lock
 # Soroban / Stellar CLI artifacts
 .soroban/
 stellar-cli-output/
+.stellar/
 
 # Temporary files
 *.tmp
 *.bak
+*.orig
+
+# Coverage reports
+coverage/
+lcov.info
+tarpaulin-report.html
+
+# Profiling
+*.profdata
+*.profraw

--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -30,6 +30,8 @@ pub enum ContractError {
     /// A new proposal cannot overwrite it; wait for the timelock to expire and execute,
     /// or allow the existing proposal to lapse before re-proposing.
     ProposalAlreadyExists = 16,
+    /// The batch exceeds the maximum allowed size.
+    BatchTooLarge = 17,
 }
 
 #[contracttype]
@@ -65,6 +67,16 @@ pub struct AssetTypePage {
     pub total: u32,
 }
 
+/// Paginated result for `get_assets_by_owner_paginated`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OwnerPage {
+    /// Asset IDs for the requested page.
+    pub assets: Vec<u64>,
+    /// Total number of assets owned by this address across all pages.
+    pub total: u32,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TimelockProposal {
@@ -88,6 +100,9 @@ const ADMIN_KEY: Symbol = symbol_short!("ADMIN");
 const ASSET_TYPE_PREFIX: Symbol = symbol_short!("AST_TYPE");
 const PENDING_ADMIN_KEY: Symbol = symbol_short!("PADMIN");
 const DECOMM_PREFIX: Symbol = symbol_short!("DECOMM");
+
+/// Maximum number of assets that may be registered in a single batch call.
+const MAX_BATCH_SIZE: u32 = 50;
 
 /// Soroban persistent-storage TTL constants.
 /// 1 ledger ≈ 5 seconds → 518_400 ledgers ≈ 30 days.
@@ -465,6 +480,10 @@ impl AssetRegistry {
         owner.require_auth();
         require_non_empty_vec(&assets, "assets");
 
+        if assets.len() > MAX_BATCH_SIZE {
+            panic_with_error!(&env, ContractError::BatchTooLarge);
+        }
+
         let mut ids: Vec<u64> = Vec::new(&env);
         // Track (asset_type, meta_hash) pairs to detect in-batch duplicates
         let mut batch_type_meta: Vec<(Symbol, BytesN<32>)> = Vec::new(&env);
@@ -712,6 +731,53 @@ impl AssetRegistry {
             page_assets.push_back(all_assets.get(i).unwrap());
         }
         page_assets
+    }
+
+    /// Returns a page of asset IDs for the given owner together with the total count.
+    ///
+    /// # Arguments
+    /// * `owner` - The address of the asset owner
+    /// * `page` - Zero-based page index
+    /// * `page_size` - Maximum number of asset IDs per page (capped at 100)
+    ///
+    /// # Returns
+    /// `OwnerPage` containing the requested slice and the total asset count for this owner
+    pub fn get_assets_by_owner_paginated(env: Env, owner: Address, page: u32, page_size: u32) -> OwnerPage {
+        const MAX_PAGE_SIZE: u32 = 100;
+        let page_size = page_size.min(MAX_PAGE_SIZE);
+
+        let key = owner_index_key(&owner);
+        let all: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        if env.storage().persistent().has(&key) {
+            env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        }
+
+        let total = all.len();
+
+        if page_size == 0 {
+            return OwnerPage { assets: Vec::new(&env), total };
+        }
+
+        let offset = match page.checked_mul(page_size) {
+            Some(o) => o,
+            None => return OwnerPage { assets: Vec::new(&env), total },
+        };
+
+        if offset >= total {
+            return OwnerPage { assets: Vec::new(&env), total };
+        }
+
+        let end = (offset + page_size).min(total);
+        let mut assets = Vec::new(&env);
+        for i in offset..end {
+            assets.push_back(all.get(i).unwrap());
+        }
+
+        OwnerPage { assets, total }
     }
 
     /// Get the total count of registered assets in the system.
@@ -2431,6 +2497,45 @@ mod tests {
     }
 
     #[test]
+    fn test_get_assets_by_owner_paginated_returns_page_and_total() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin, &admin);
+        client.add_asset_type(&admin, &symbol_short!("GENSET"));
+
+        let owner = Address::generate(&env);
+        let id1 = client.register_asset(&symbol_short!("GENSET"), &String::from_str(&env, "P1"), &unique_serial(&env), &owner);
+        let id2 = client.register_asset(&symbol_short!("GENSET"), &String::from_str(&env, "P2"), &unique_serial(&env), &owner);
+        let id3 = client.register_asset(&symbol_short!("GENSET"), &String::from_str(&env, "P3"), &unique_serial(&env), &owner);
+
+        let page0 = client.get_assets_by_owner_paginated(&owner, &0, &2);
+        assert_eq!(page0.total, 3);
+        assert_eq!(page0.assets.len(), 2);
+        assert_eq!(page0.assets.get(0).unwrap(), id1);
+        assert_eq!(page0.assets.get(1).unwrap(), id2);
+
+        let page1 = client.get_assets_by_owner_paginated(&owner, &1, &2);
+        assert_eq!(page1.total, 3);
+        assert_eq!(page1.assets.len(), 1);
+        assert_eq!(page1.assets.get(0).unwrap(), id3);
+
+        // Out-of-range page returns empty assets but still correct total
+        let page2 = client.get_assets_by_owner_paginated(&owner, &5, &2);
+        assert_eq!(page2.total, 3);
+        assert_eq!(page2.assets.len(), 0);
+
+        // Unknown owner returns total=0
+        let unknown = Address::generate(&env);
+        let empty = client.get_assets_by_owner_paginated(&unknown, &0, &10);
+        assert_eq!(empty.total, 0);
+        assert_eq!(empty.assets.len(), 0);
+    }
+
+    #[test]
     fn test_get_assets_by_owner_updated_after_transfer() {
         let env = Env::default();
         env.mock_all_auths();
@@ -2873,6 +2978,37 @@ mod tests {
         client.unpause(&admin);
         let id3 = client.batch_register_assets(&owner, &Vec::new(&env));
         assert_eq!(id3.len(), 0);
+    }
+
+    #[test]
+    fn test_batch_register_assets_rejects_oversized_batch() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin, &admin);
+        client.add_asset_type(&admin, &symbol_short!("GENSET"));
+
+        let owner = Address::generate(&env);
+        // Build 51 items — one over MAX_BATCH_SIZE (50)
+        let mut batch: Vec<AssetInput> = Vec::new(&env);
+        for _ in 0u32..51 {
+            batch.push_back(AssetInput {
+                asset_type: symbol_short!("GENSET"),
+                metadata: String::from_str(&env, "meta"),
+                serial_number: unique_serial(&env),
+            });
+        }
+
+        let result = client.try_batch_register_assets(&owner, &batch);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::BatchTooLarge as u32,
+            ))),
+        );
     }
 
     #[test]

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -79,8 +79,9 @@ const REVOKE_TOPIC: Symbol = symbol_short!("REV_CRED");
 const MIN_VALIDITY_PERIOD: u64 = 86_400;
 const EVENT_PROP_ADMIN: Symbol = symbol_short!("PROP_ADM");
 const TIMELOCK_DELAY_SECS: u64 = 48 * 60 * 60;
-/// Grace period allowing engineers to work after credential expiry (7 days).
-const GRACE_PERIOD_SECS: u64 = 7 * 86_400;
+/// Default grace period allowing engineers to work after credential expiry (7 days).
+const DEFAULT_GRACE_PERIOD_SECS: u64 = 7 * 86_400;
+const GRACE_PERIOD_KEY: Symbol = symbol_short!("GRACE_P");
 
 /// Soroban persistent-storage TTL constants.
 /// 1 ledger ≈ 5 seconds → 518_400 ledgers ≈ 30 days.
@@ -550,7 +551,7 @@ impl EngineerRegistry {
 
     /// Get the detailed credential status with grace period support.
     /// Distinguishes between valid, in grace period, hard-expired, revoked, and not found.
-    /// Grace period: [`GRACE_PERIOD_SECS`] (7 days) after expiry allows continued operations.
+    /// Grace period is configurable via [`set_grace_period`] (default: 7 days).
     ///
     /// # Arguments
     /// * `engineer` - The address of the engineer to check
@@ -558,6 +559,11 @@ impl EngineerRegistry {
     /// # Returns
     /// A CredentialStatus enum with the detailed credential state
     pub fn get_credential_status(env: Env, engineer: Address) -> CredentialStatus {
+        let grace_period: u64 = env
+            .storage()
+            .persistent()
+            .get(&GRACE_PERIOD_KEY)
+            .unwrap_or(DEFAULT_GRACE_PERIOD_SECS);
         match env
             .storage()
             .persistent()
@@ -570,7 +576,7 @@ impl EngineerRegistry {
                     let now = env.ledger().timestamp();
                     if now < e.expires_at {
                         CredentialStatus::Valid
-                    } else if now < e.expires_at + GRACE_PERIOD_SECS {
+                    } else if now < e.expires_at + grace_period {
                         CredentialStatus::GracePeriod
                     } else {
                         CredentialStatus::HardExpired
@@ -747,6 +753,39 @@ impl EngineerRegistry {
     /// `true` if paused; `false` otherwise
     pub fn is_paused(env: Env) -> bool {
         is_paused(&env)
+    }
+
+    /// Admin-only function to set the configurable grace period for credential renewal.
+    /// After a credential expires, engineers within the grace window still show as
+    /// [`CredentialStatus::GracePeriod`] rather than [`CredentialStatus::HardExpired`].
+    ///
+    /// # Arguments
+    /// * `admin` - The current admin address
+    /// * `secs` - Grace period in seconds (0 disables the grace window entirely)
+    ///
+    /// # Panics
+    /// - [`ContractError::UnauthorizedAdmin`] if caller is not the current admin
+    pub fn set_grace_period(env: Env, admin: Address, secs: u64) {
+        admin.require_auth();
+        let stored_admin: Address = Self::get_admin(env.clone());
+        if stored_admin != admin {
+            panic_with_error!(&env, ContractError::UnauthorizedAdmin);
+        }
+        env.storage().persistent().set(&GRACE_PERIOD_KEY, &secs);
+        env.storage()
+            .persistent()
+            .extend_ttl(&GRACE_PERIOD_KEY, TTL_THRESHOLD, TTL_TARGET);
+        env.events()
+            .publish((symbol_short!("ADM_AUD"), symbol_short!("SET_GRACE")), (admin, secs));
+    }
+
+    /// Returns the current grace period in seconds.
+    /// If never set by admin, returns the default (7 days = 604_800 seconds).
+    pub fn get_grace_period(env: Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&GRACE_PERIOD_KEY)
+            .unwrap_or(DEFAULT_GRACE_PERIOD_SECS)
     }
 
     /// Check if an issuer is in the trusted issuers list.
@@ -3265,6 +3304,60 @@ mod tests {
 
         let record = client.get_engineer(&engineer);
         assert!(record.expires_at > env.ledger().timestamp());
+    }
+
+    #[test]
+    fn test_get_grace_period_returns_default() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+        // Default is 7 days = 604_800 seconds
+        assert_eq!(client.get_grace_period(), 7 * 86_400u64);
+    }
+
+    #[test]
+    fn test_set_grace_period_updates_credential_status() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+        let base_time = env.ledger().timestamp();
+        let validity = 86_400u64;
+        client.register_engineer(&engineer, &hash, &issuer, &validity);
+
+        // Shrink grace period to 1 hour
+        client.set_grace_period(&admin, &3_600u64);
+        assert_eq!(client.get_grace_period(), 3_600u64);
+
+        // 2 hours after expiry → past 1h grace period → HardExpired
+        env.ledger().set_timestamp(base_time + validity + 7_200);
+        assert_eq!(
+            client.get_credential_status(&engineer),
+            CredentialStatus::HardExpired
+        );
+
+        // Within 1h grace period → GracePeriod
+        env.ledger().set_timestamp(base_time + validity + 1_800);
+        assert_eq!(
+            client.get_credential_status(&engineer),
+            CredentialStatus::GracePeriod
+        );
+    }
+
+    #[test]
+    fn test_set_grace_period_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        let non_admin = Address::generate(&env);
+        let result = client.try_set_grace_period(&non_admin, &3_600u64);
+        assert!(result.is_err());
     }
 
     // --- Issue: batch_verify_engineers ---

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -1522,6 +1522,19 @@ impl Lifecycle {
         best
     }
 
+    /// View alias for [`get_last_service`].
+    /// Returns the most recent maintenance record for an asset, or `None` if no history exists.
+    /// Frontends and lenders should prefer this over fetching the full history.
+    ///
+    /// # Arguments
+    /// * `asset_id` - The unique identifier of the asset
+    ///
+    /// # Returns
+    /// `Some(MaintenanceRecord)` for the latest record, or `None` for assets with no history
+    pub fn get_last_maintenance(env: Env, asset_id: u64) -> Option<MaintenanceRecord> {
+        Self::get_last_service(env, asset_id)
+    }
+
     /// Get the current collateral score for an asset.
     /// Verifies asset exists before returning the score.
     ///
@@ -3005,6 +3018,47 @@ mod tests {
 
         let last = client.get_last_service(&asset_id).unwrap();
         assert_eq!(last.timestamp, 2000);
+        assert_eq!(last.task_type, symbol_short!("INSPECT"));
+    }
+
+    #[test]
+    fn test_get_last_maintenance_none_for_no_history() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, _, _) = setup(&env, 0);
+        let (asset_id, _) = register_asset(&env, &asset_registry_client);
+        assert_eq!(client.get_last_maintenance(&asset_id), None);
+    }
+
+    #[test]
+    fn test_get_last_maintenance_returns_most_recent() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let (asset_id, asset_owner) = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+        client.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+        env.ledger().set_timestamp(500);
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "older"),
+            &engineer,
+        );
+
+        env.ledger().set_timestamp(1500);
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("INSPECT"),
+            &String::from_str(&env, "newer"),
+            &engineer,
+        );
+
+        let last = client.get_last_maintenance(&asset_id).unwrap();
+        assert_eq!(last.timestamp, 1500);
         assert_eq!(last.task_type, symbol_short!("INSPECT"));
     }
 


### PR DESCRIPTION
(asset-registry): add OwnerPage struct and get_assets_by_owner_paginated
  - Returns paginated asset IDs with total count for a given owner
  - Capped at 100 per page, consistent with AssetTypePage pattern
  - Add test: test_get_assets_by_owner_paginated_returns_page_and_total
Closes #816  (engineer-registry): make grace period configurable
  - Replace hardcoded GRACE_PERIOD_SECS with GRACE_PERIOD_KEY in persistent storage
  - Add set_grace_period(admin, secs) and get_grace_period() functions
  - get_credential_status reads from storage, falls back to 7-day default
  - Add tests: get/set grace period, unauthorized set, credential status affected
(asset-registry): enforce max batch size in batch_register_assets
  - Add MAX_BATCH_SIZE = 50 constant
  - Add BatchTooLarge = 17 contract error
  - Panic with BatchTooLarge if assets.len() > 50
  - Add test: test_batch_register_assets_rejects_oversized_batch
 (lifecycle): add get_last_maintenance view function
  - Alias for get_last_service returning Option<MaintenanceRecord>
  - Returns None for assets with no history
  - Add tests: no-history case and most-recent-record case
chore: update .gitignore
  - Add desktop.ini, .stellar/, *.orig, coverage/, profiling artifacts

Closes #815 
Closes #816 
Closes #817 
Closes #818 
