### PR TITLE
feat(#870): batch asset registration tests and compile fixes

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -838,9 +838,6 @@ impl AssetRegistry {
     /// - [`ContractError::AdminAlreadyInitialized`] if admin has already been initialized
     /// - [`ContractError::UnauthorizedAdmin`] if deployer is not the transaction invoker
     pub fn initialize_admin(env: Env, deployer: Address, admin: Address) {
-        if deployer != env.invoker() {
-            panic_with_error!(&env, ContractError::UnauthorizedAdmin);
-        }
         deployer.require_auth();
         if env.storage().instance().has(&ADMIN_KEY) {
             panic_with_error!(&env, ContractError::AdminAlreadyInitialized);
@@ -3132,6 +3129,116 @@ mod tests {
         assert_eq!(ids.get(0).unwrap(), 2);
         assert_eq!(ids.get(1).unwrap(), 3);
         assert_eq!(ids.get(2).unwrap(), 4);
+    }
+
+    #[test]
+    fn test_batch_register_assets_rejects_in_batch_serial_duplicate() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin, &admin);
+        client.add_asset_type(&admin, &symbol_short!("GENSET"));
+
+        let owner = Address::generate(&env);
+        let shared_serial = String::from_str(&env, "SN-SAME-001");
+        let mut batch = Vec::new(&env);
+        batch.push_back(AssetInput {
+            asset_type: symbol_short!("GENSET"),
+            metadata: String::from_str(&env, "Machine A"),
+            serial_number: shared_serial.clone(),
+        });
+        batch.push_back(AssetInput {
+            asset_type: symbol_short!("GENSET"),
+            metadata: String::from_str(&env, "Machine B"),
+            serial_number: shared_serial,
+        });
+
+        let result = client.try_batch_register_assets(&owner, &batch);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::DuplicateAsset as u32,
+            ))),
+        );
+    }
+
+    #[test]
+    fn test_batch_register_assets_rejects_invalid_asset_type() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin, &admin);
+        client.add_asset_type(&admin, &symbol_short!("GENSET"));
+
+        let owner = Address::generate(&env);
+        let mut batch = Vec::new(&env);
+        batch.push_back(AssetInput {
+            asset_type: symbol_short!("GENSET"),
+            metadata: String::from_str(&env, "Valid asset"),
+            serial_number: unique_serial(&env),
+        });
+        batch.push_back(AssetInput {
+            asset_type: symbol_short!("UNKNOWN"),
+            metadata: String::from_str(&env, "Invalid type asset"),
+            serial_number: unique_serial(&env),
+        });
+
+        let result = client.try_batch_register_assets(&owner, &batch);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::InvalidAssetType as u32,
+            ))),
+        );
+    }
+
+    #[test]
+    fn test_batch_register_assets_owner_index_correct() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin, &admin);
+        client.add_asset_type(&admin, &symbol_short!("GENSET"));
+
+        let owner = Address::generate(&env);
+
+        // Pre-register one asset so owner index is non-empty before the batch
+        let pre_id = client.register_asset(
+            &symbol_short!("GENSET"),
+            &String::from_str(&env, "Pre-existing"),
+            &unique_serial(&env),
+            &owner,
+        );
+
+        let mut batch = Vec::new(&env);
+        batch.push_back(AssetInput {
+            asset_type: symbol_short!("GENSET"),
+            metadata: String::from_str(&env, "Batch A"),
+            serial_number: unique_serial(&env),
+        });
+        batch.push_back(AssetInput {
+            asset_type: symbol_short!("GENSET"),
+            metadata: String::from_str(&env, "Batch B"),
+            serial_number: unique_serial(&env),
+        });
+
+        let batch_ids = client.batch_register_assets(&owner, &batch);
+
+        let owned = client.get_assets_by_owner(&owner);
+        // All three IDs must be present in the owner index
+        assert_eq!(owned.len(), 3);
+        assert!(owned.contains(&pre_id));
+        assert!(owned.contains(&batch_ids.get(0).unwrap()));
+        assert!(owned.contains(&batch_ids.get(1).unwrap()));
     }
 
     #[test]

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -340,7 +340,7 @@ impl EngineerRegistry {
                 } else if env.ledger().timestamp() < e.expires_at {
                     CredentialStatus::Valid
                 } else {
-                    CredentialStatus::Expired
+                    CredentialStatus::HardExpired
                 }
             }
             None => CredentialStatus::NotFound,
@@ -371,7 +371,7 @@ impl EngineerRegistry {
                     } else if now < e.expires_at {
                         CredentialStatus::Valid
                     } else {
-                        CredentialStatus::Expired
+                        CredentialStatus::HardExpired
                     }
                 }
                 None => CredentialStatus::NotFound,
@@ -611,9 +611,6 @@ impl EngineerRegistry {
     /// - [`ContractError::AdminAlreadyInitialized`] if admin has already been initialized
     /// - [`ContractError::UnauthorizedAdmin`] if deployer is not the transaction invoker
     pub fn initialize_admin(env: Env, deployer: Address, admin: Address) {
-        if deployer != env.invoker() {
-            panic_with_error!(&env, ContractError::UnauthorizedAdmin);
-        }
         deployer.require_auth();
         if env.storage().instance().has(&admin_key()) {
             panic_with_error!(&env, ContractError::AdminAlreadyInitialized);
@@ -3271,10 +3268,6 @@ mod tests {
 
     #[test]
     fn test_batch_verify_engineers_all_valid() {
-    // --- #752: upgrade timelock tests ---
-
-    #[test]
-    fn test_execute_upgrade_before_timelock_fails() {
         let env = Env::default();
         env.mock_all_auths();
         let (client, admin) = setup(&env);
@@ -3298,8 +3291,14 @@ mod tests {
         assert!(results.get(2).unwrap());
     }
 
+    // --- #752: upgrade timelock tests ---
+
     #[test]
-    fn test_batch_verify_engineers_mixed() {
+    fn test_execute_upgrade_before_timelock_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
         let hash = BytesN::from_array(&env, &[0xabu8; 32]);
         client.propose_upgrade(&admin, &hash);
 
@@ -3313,7 +3312,7 @@ mod tests {
     }
 
     #[test]
-    fn test_execute_upgrade_after_timelock_succeeds() {
+    fn test_batch_verify_engineers_mixed() {
         let env = Env::default();
         env.mock_all_auths();
         let (client, admin) = setup(&env);
@@ -3342,7 +3341,11 @@ mod tests {
     }
 
     #[test]
-    fn test_batch_verify_engineers_all_invalid() {
+    fn test_execute_upgrade_after_timelock_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
         let hash = BytesN::from_array(&env, &[0xabu8; 32]);
         client.propose_upgrade(&admin, &hash);
 
@@ -3353,7 +3356,7 @@ mod tests {
     }
 
     #[test]
-    fn test_execute_upgrade_without_proposal_fails() {
+    fn test_batch_verify_engineers_all_invalid() {
         let env = Env::default();
         env.mock_all_auths();
         let (client, admin) = setup(&env);
@@ -3377,6 +3380,14 @@ mod tests {
         assert!(!results.get(0).unwrap(), "revoked engineer must be false");
         assert!(!results.get(1).unwrap(), "revoked engineer must be false");
         assert!(!results.get(2).unwrap(), "never-registered engineer must be false");
+    }
+
+    #[test]
+    fn test_execute_upgrade_without_proposal_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
         let result = client.try_execute_upgrade(&admin);
         assert_eq!(
             result,

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -1084,8 +1084,6 @@ impl Lifecycle {
         use engineer_registry::CredentialStatus;
         let status = registry.verify_engineer(&engineer);
         if status != CredentialStatus::Valid {
-        let verified = registry.verify_engineer(&engineer).unwrap_or(false);
-        if !verified {
             panic_with_error!(&env, ContractError::UnauthorizedEngineer);
         }
         require_engineer_authorized(&env, asset_id, &engineer);
@@ -1282,11 +1280,6 @@ impl Lifecycle {
         use engineer_registry::CredentialStatus;
         let status = engineer_registry_client.verify_engineer(&engineer);
         if status != CredentialStatus::Valid {
-        let mut batch = Vec::new(&env);
-        batch.push_back(engineer.clone());
-        let results = engineer_registry_client.batch_verify_engineers(&batch);
-        let verified = results.get(0).unwrap_or(false);
-        if !verified {
             panic_with_error!(&env, ContractError::UnauthorizedEngineer);
         }
         require_engineer_authorized(&env, asset_id, &engineer);


### PR DESCRIPTION
## Summary

Closes #870 — Implement Batch Asset Registration with Deduplication.

The `batch_register_assets` function was already implemented. This PR adds the missing test coverage and fixes pre-existing compile errors that blocked the test suite.

## Changes

### New tests (asset-registry)
- `test_batch_register_assets_rejects_in_batch_serial_duplicate` — verifies two assets with the same serial number in a single batch are rejected with `DuplicateAsset`
- `test_batch_register_assets_rejects_invalid_asset_type` — verifies a batch containing an unallowlisted asset type is rejected with `InvalidAssetType`
- `test_batch_register_assets_owner_index_correct` — verifies the owner index contains all pre-existing and batch-registered asset IDs after a batch call

### Pre-existing compile fixes
- **asset-registry / engineer-registry**: Removed `env.invoker()` call removed in Soroban SDK v22; `deployer.require_auth()` already provides the auth check
- **engineer-registry**: Fixed `CredentialStatus::Expired` → `CredentialStatus::HardExpired` to match the actual enum variant
- **engineer-registry**: Disentangled corrupted `test_batch_verify_engineers_*` and `test_execute_upgrade_*` tests that were merged with wrong bodies
- **lifecycle**: Closed two unclosed `if status != CredentialStatus::Valid` blocks in `submit_maintenance` and `batch_submit_maintenance`