### PR TITLE
feat: implement engineer credential grace period (#878)

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -838,9 +838,6 @@ impl AssetRegistry {
     /// - [`ContractError::AdminAlreadyInitialized`] if admin has already been initialized
     /// - [`ContractError::UnauthorizedAdmin`] if deployer is not the transaction invoker
     pub fn initialize_admin(env: Env, deployer: Address, admin: Address) {
-        if deployer != env.invoker() {
-            panic_with_error!(&env, ContractError::UnauthorizedAdmin);
-        }
         deployer.require_auth();
         if env.storage().instance().has(&ADMIN_KEY) {
             panic_with_error!(&env, ContractError::AdminAlreadyInitialized);

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -340,7 +340,7 @@ impl EngineerRegistry {
                 } else if env.ledger().timestamp() < e.expires_at {
                     CredentialStatus::Valid
                 } else {
-                    CredentialStatus::Expired
+                    CredentialStatus::HardExpired
                 }
             }
             None => CredentialStatus::NotFound,
@@ -371,7 +371,7 @@ impl EngineerRegistry {
                     } else if now < e.expires_at {
                         CredentialStatus::Valid
                     } else {
-                        CredentialStatus::Expired
+                        CredentialStatus::HardExpired
                     }
                 }
                 None => CredentialStatus::NotFound,
@@ -611,9 +611,6 @@ impl EngineerRegistry {
     /// - [`ContractError::AdminAlreadyInitialized`] if admin has already been initialized
     /// - [`ContractError::UnauthorizedAdmin`] if deployer is not the transaction invoker
     pub fn initialize_admin(env: Env, deployer: Address, admin: Address) {
-        if deployer != env.invoker() {
-            panic_with_error!(&env, ContractError::UnauthorizedAdmin);
-        }
         deployer.require_auth();
         if env.storage().instance().has(&admin_key()) {
             panic_with_error!(&env, ContractError::AdminAlreadyInitialized);
@@ -1081,10 +1078,10 @@ mod tests {
 
         client.add_trusted_issuer(&admin, &issuer);
         client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
-        assert!(client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
 
         client.revoke_credential(&engineer);
-        assert!(!client.verify_engineer(&engineer).unwrap_or(true));
+        assert_ne!(client.verify_engineer(&engineer), CredentialStatus::Valid);
     }
 
     #[test]
@@ -1101,11 +1098,11 @@ mod tests {
         client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
 
         // Sanity: engineer is initially verified
-        assert!(client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
 
         // Revoke credentials and verify immediately returns false
         client.revoke_credential(&engineer);
-        assert!(!client.verify_engineer(&engineer).unwrap_or(true));
+        assert_ne!(client.verify_engineer(&engineer), CredentialStatus::Valid);
     }
 
     #[test]
@@ -1392,7 +1389,7 @@ mod tests {
         use soroban_sdk::TryIntoVal;
         let upgrade_event = events.iter().find(|(_, topics, _)| {
             if let Some(val) = topics.get(0) {
-                if let Ok(s) = val.try_into_val::<_, Symbol>(&env) {
+                if let Ok(s) = TryIntoVal::<_, Symbol>::try_into_val(&val, &env) {
                     return s == symbol_short!("UPGRADE");
                 }
             }
@@ -1636,7 +1633,7 @@ mod tests {
         client.unpause(&admin);
         client.add_trusted_issuer(&admin, &issuer);
         client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
-        assert!(client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
     }
 
     #[test]
@@ -1708,12 +1705,12 @@ mod tests {
         client.add_trusted_issuer(&admin, &issuer);
         // validity_period of 86_400 seconds (minimum)
         client.register_engineer(&engineer, &hash, &issuer, &86_400);
-        assert!(client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
 
         // Advance ledger past expiry
         env.ledger()
             .with_mut(|li| li.timestamp = li.timestamp + 86_401);
-        assert!(!client.verify_engineer(&engineer).unwrap_or(true));
+        assert_ne!(client.verify_engineer(&engineer), CredentialStatus::Valid);
     }
 
     #[test]
@@ -1732,7 +1729,7 @@ mod tests {
         // Advance to just before expiry
         env.ledger()
             .with_mut(|li| li.timestamp = li.timestamp + 86_399);
-        assert!(client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
     }
 
     #[test]
@@ -1986,7 +1983,7 @@ mod tests {
         client.pause(&admin);
 
         // Read-only access should still work while paused
-        assert!(client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
         let fetched_engineer = client.get_engineer(&engineer);
         assert_eq!(fetched_engineer.address, engineer);
         assert!(fetched_engineer.active);
@@ -2078,11 +2075,11 @@ mod tests {
         // Advance past original expiry
         env.ledger()
             .with_mut(|li| li.timestamp = li.timestamp + 86_401);
-        assert!(!client.verify_engineer(&engineer).unwrap_or(true));
+        assert_ne!(client.verify_engineer(&engineer), CredentialStatus::Valid);
 
         // Renew for another 86_400 seconds from now
         client.renew_credential(&engineer, &86_400);
-        assert!(client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
 
         let record = client.get_engineer(&engineer);
         assert_eq!(record.expires_at, env.ledger().timestamp() + 86_400);
@@ -2180,7 +2177,7 @@ mod tests {
         assert_eq!(renewed.issuer, original.issuer);
         assert_eq!(renewed.expires_at, original.expires_at + 86_400);
         assert!(renewed.expires_at > original.expires_at);
-        assert!(client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
     }
 
     #[test]
@@ -2397,15 +2394,15 @@ mod tests {
         client.register_engineer(&engineer2, &hash2, &issuer, &31_536_000);
 
         // Verify engineers are active
-        assert!(client.verify_engineer(&engineer1).unwrap_or(false));
-        assert!(client.verify_engineer(&engineer2).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer1), CredentialStatus::Valid);
+        assert_eq!(client.verify_engineer(&engineer2), CredentialStatus::Valid);
 
         // Remove the trusted issuer
         client.remove_trusted_issuer(&admin, &issuer);
 
         // Verify engineers are now revoked
-        assert!(!client.verify_engineer(&engineer1).unwrap_or(true));
-        assert!(!client.verify_engineer(&engineer2).unwrap_or(true));
+        assert_ne!(client.verify_engineer(&engineer1), CredentialStatus::Valid);
+        assert_ne!(client.verify_engineer(&engineer2), CredentialStatus::Valid);
 
         // Check status
         assert_eq!(
@@ -2560,12 +2557,12 @@ mod tests {
 
         // Revoke the credential
         client.revoke_credential(&engineer);
-        assert!(!client.verify_engineer(&engineer).unwrap_or(true));
+        assert_ne!(client.verify_engineer(&engineer), CredentialStatus::Valid);
 
         // Should be able to re-register after revocation
         let new_hash = BytesN::from_array(&env, &[2u8; 32]);
         client.register_engineer(&engineer, &new_hash, &issuer, &31_536_000);
-        assert!(client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
     }
 
     #[test]
@@ -2583,7 +2580,7 @@ mod tests {
 
         // First registration succeeds
         client.register_engineer(&engineer, &hash1, &issuer, &31_536_000);
-        assert!(client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
 
         // Second registration with same engineer (still active) must panic
         let result = client.try_register_engineer(&engineer, &hash2, &issuer, &31_536_000);
@@ -2959,9 +2956,9 @@ mod tests {
 
         let results = client.batch_verify_engineers(&soroban_sdk::vec![&env, e1, e2, e3]);
         assert_eq!(results.len(), 3);
-        assert!(results.get(0).unwrap());
-        assert!(results.get(1).unwrap());
-        assert!(results.get(2).unwrap());
+        assert_eq!(results.get(0).unwrap(), CredentialStatus::Valid);
+        assert_eq!(results.get(1).unwrap(), CredentialStatus::Valid);
+        assert_eq!(results.get(2).unwrap(), CredentialStatus::Valid);
     }
 
     #[test]
@@ -2982,8 +2979,8 @@ mod tests {
 
         let results = client.batch_verify_engineers(&soroban_sdk::vec![&env, e1, e2]);
         assert_eq!(results.len(), 2);
-        assert!(!results.get(0).unwrap());
-        assert!(!results.get(1).unwrap());
+        assert_ne!(results.get(0).unwrap(), CredentialStatus::Valid);
+        assert_ne!(results.get(1).unwrap(), CredentialStatus::Valid);
     }
 
     #[test]
@@ -3031,38 +3028,38 @@ mod tests {
         let engineer = Address::generate(&env);
         let never_registered = Address::generate(&env);
 
-        // Never-registered engineer returns None
+        // Never-registered engineer returns NotFound
         assert_eq!(
             client.verify_engineer(&never_registered),
-            None,
-            "never-registered engineer should return None"
+            CredentialStatus::NotFound,
+            "never-registered engineer should return NotFound"
         );
 
         // Register an engineer
         client.register_engineer(&engineer, &BytesN::from_array(&env, &[1u8; 32]), &issuer, &31_536_000);
 
-        // Active engineer returns Some(true)
+        // Active engineer returns Valid
         assert_eq!(
             client.verify_engineer(&engineer),
-            Some(true),
-            "active engineer should return Some(true)"
+            CredentialStatus::Valid,
+            "active engineer should return Valid"
         );
 
         // Revoke the engineer
         client.revoke_credential(&engineer);
 
-        // Revoked engineer returns Some(false)
+        // Revoked engineer returns Revoked
         assert_eq!(
             client.verify_engineer(&engineer),
-            Some(false),
-            "revoked engineer should return Some(false)"
+            CredentialStatus::Revoked,
+            "revoked engineer should return Revoked"
         );
 
-        // Never-registered still returns None
+        // Never-registered still returns NotFound
         assert_eq!(
             client.verify_engineer(&never_registered),
-            None,
-            "never-registered engineer should still return None after other operations"
+            CredentialStatus::NotFound,
+            "never-registered engineer should still return NotFound after other operations"
         );
     }
 
@@ -3271,10 +3268,6 @@ mod tests {
 
     #[test]
     fn test_batch_verify_engineers_all_valid() {
-    // --- #752: upgrade timelock tests ---
-
-    #[test]
-    fn test_execute_upgrade_before_timelock_fails() {
         let env = Env::default();
         env.mock_all_auths();
         let (client, admin) = setup(&env);
@@ -3293,27 +3286,13 @@ mod tests {
         let results = client.batch_verify_engineers(&batch);
 
         assert_eq!(results.len(), 3);
-        assert!(results.get(0).unwrap());
-        assert!(results.get(1).unwrap());
-        assert!(results.get(2).unwrap());
+        assert_eq!(results.get(0).unwrap(), CredentialStatus::Valid);
+        assert_eq!(results.get(1).unwrap(), CredentialStatus::Valid);
+        assert_eq!(results.get(2).unwrap(), CredentialStatus::Valid);
     }
 
     #[test]
     fn test_batch_verify_engineers_mixed() {
-        let hash = BytesN::from_array(&env, &[0xabu8; 32]);
-        client.propose_upgrade(&admin, &hash);
-
-        let result = client.try_execute_upgrade(&admin);
-        assert_eq!(
-            result,
-            Err(Ok(soroban_sdk::Error::from_contract_error(
-                ContractError::TimelockNotExpired as u32,
-            ))),
-        );
-    }
-
-    #[test]
-    fn test_execute_upgrade_after_timelock_succeeds() {
         let env = Env::default();
         env.mock_all_auths();
         let (client, admin) = setup(&env);
@@ -3329,31 +3308,19 @@ mod tests {
         client.register_engineer(&expired, &BytesN::from_array(&env, &[3u8; 32]), &issuer, &86_400);
 
         client.revoke_credential(&revoked);
-        // Advance time past the expired engineer's validity
         env.ledger().with_mut(|li| li.timestamp += 86_401);
 
         let batch = soroban_sdk::vec![&env, valid.clone(), revoked.clone(), expired.clone()];
         let results = client.batch_verify_engineers(&batch);
 
         assert_eq!(results.len(), 3);
-        assert!(results.get(0).unwrap(), "valid engineer must be true");
-        assert!(!results.get(1).unwrap(), "revoked engineer must be false");
-        assert!(!results.get(2).unwrap(), "expired engineer must be false");
+        assert_eq!(results.get(0).unwrap(), CredentialStatus::Valid, "valid engineer must be Valid");
+        assert_eq!(results.get(1).unwrap(), CredentialStatus::Revoked, "revoked engineer must be Revoked");
+        assert_ne!(results.get(2).unwrap(), CredentialStatus::Valid, "expired engineer must not be Valid");
     }
 
     #[test]
     fn test_batch_verify_engineers_all_invalid() {
-        let hash = BytesN::from_array(&env, &[0xabu8; 32]);
-        client.propose_upgrade(&admin, &hash);
-
-        let base = env.ledger().timestamp();
-        env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
-
-        client.execute_upgrade(&admin);
-    }
-
-    #[test]
-    fn test_execute_upgrade_without_proposal_fails() {
         let env = Env::default();
         env.mock_all_auths();
         let (client, admin) = setup(&env);
@@ -3374,9 +3341,52 @@ mod tests {
         let results = client.batch_verify_engineers(&batch);
 
         assert_eq!(results.len(), 3);
-        assert!(!results.get(0).unwrap(), "revoked engineer must be false");
-        assert!(!results.get(1).unwrap(), "revoked engineer must be false");
-        assert!(!results.get(2).unwrap(), "never-registered engineer must be false");
+        assert_ne!(results.get(0).unwrap(), CredentialStatus::Valid, "revoked engineer must not be Valid");
+        assert_ne!(results.get(1).unwrap(), CredentialStatus::Valid, "revoked engineer must not be Valid");
+        assert_eq!(results.get(2).unwrap(), CredentialStatus::NotFound, "never-registered engineer must be NotFound");
+    }
+
+    // --- #752: upgrade timelock tests ---
+
+    #[test]
+    fn test_execute_upgrade_before_timelock_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let hash = BytesN::from_array(&env, &[0xabu8; 32]);
+        client.propose_upgrade(&admin, &hash);
+
+        let result = client.try_execute_upgrade(&admin);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::TimelockNotExpired as u32,
+            ))),
+        );
+    }
+
+    #[test]
+    fn test_execute_upgrade_after_timelock_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let hash = BytesN::from_array(&env, &[0xabu8; 32]);
+        client.propose_upgrade(&admin, &hash);
+
+        let base = env.ledger().timestamp();
+        env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+
+        client.execute_upgrade(&admin);
+    }
+
+    #[test]
+    fn test_execute_upgrade_without_proposal_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
         let result = client.try_execute_upgrade(&admin);
         assert_eq!(
             result,
@@ -3461,10 +3471,10 @@ mod tests {
         let hash = BytesN::from_array(&env, &[1u8; 32]);
 
         client.add_trusted_issuer(&admin, &issuer);
-        client.register_engineer(&engineer, &hash, &issuer, &100); // 100 seconds expiry
+        client.register_engineer(&engineer, &hash, &issuer, &86_400); // minimum validity
 
-        // Set ledger time to 101 seconds (after expiry)
-        env.ledger().with_timestamp(101);
+        // Set ledger time past expiry
+        env.ledger().set_timestamp(86_401);
 
         assert!(!client.is_engineer_active(&engineer));
     }

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -86,6 +86,7 @@ fn frozen_key(asset_id: u64) -> (Symbol, u64) {
 
 fn frozen_score_key(asset_id: u64) -> (Symbol, u64) {
     (symbol_short!("FRZ_SCR"), asset_id)
+}
 fn revoke_eng_timelock_key(asset_id: u64, engineer: &Address) -> (Symbol, u64, Address) {
     (symbol_short!("RVK_TL"), asset_id, engineer.clone())
 }
@@ -260,13 +261,24 @@ fn verify_asset_exists(env: &Env, asset_registry: &Address, asset_id: &u64) {
 
 // Minimal client interface for cross-contract call to EngineerRegistry
 mod engineer_registry {
-    use soroban_sdk::{contractclient, Address, Env, Vec};
+    use soroban_sdk::{contractclient, contracttype, Address, Env, Vec};
+
+    #[contracttype]
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub enum CredentialStatus {
+        Valid = 0,
+        GracePeriod = 1,
+        HardExpired = 2,
+        Revoked = 3,
+        NotFound = 4,
+    }
 
     #[allow(dead_code)]
     #[contractclient(name = "EngineerRegistryClient")]
     pub trait EngineerRegistry {
-        fn verify_engineer(env: Env, engineer: Address) -> Option<bool>;
-        fn batch_verify_engineers(env: Env, engineers: Vec<Address>) -> Vec<bool>;
+        fn verify_engineer(env: Env, engineer: Address) -> CredentialStatus;
+        fn batch_verify_engineers(env: Env, engineers: Vec<Address>) -> Vec<CredentialStatus>;
+        fn get_credential_status(env: Env, engineer: Address) -> CredentialStatus;
     }
 }
 
@@ -555,9 +567,6 @@ impl Lifecycle {
         admin: Address,
         max_history: u32,
     ) {
-        if deployer != env.invoker() {
-            panic_with_error!(&env, ContractError::UnauthorizedAdmin);
-        }
         deployer.require_auth();
         if env.storage().persistent().has(&CONFIG) {
             panic_with_error!(&env, ContractError::AlreadyInitialized);
@@ -1082,10 +1091,8 @@ impl Lifecycle {
         let registry_id = get_engineer_registry_addr(&env);
         let registry = engineer_registry::EngineerRegistryClient::new(&env, &registry_id);
         use engineer_registry::CredentialStatus;
-        let status = registry.verify_engineer(&engineer);
-        if status != CredentialStatus::Valid {
-        let verified = registry.verify_engineer(&engineer).unwrap_or(false);
-        if !verified {
+        let status = registry.get_credential_status(&engineer);
+        if status != CredentialStatus::Valid && status != CredentialStatus::GracePeriod {
             panic_with_error!(&env, ContractError::UnauthorizedEngineer);
         }
         require_engineer_authorized(&env, asset_id, &engineer);
@@ -1280,13 +1287,8 @@ impl Lifecycle {
         let engineer_registry_client =
             engineer_registry::EngineerRegistryClient::new(&env, &engineer_registry);
         use engineer_registry::CredentialStatus;
-        let status = engineer_registry_client.verify_engineer(&engineer);
-        if status != CredentialStatus::Valid {
-        let mut batch = Vec::new(&env);
-        batch.push_back(engineer.clone());
-        let results = engineer_registry_client.batch_verify_engineers(&batch);
-        let verified = results.get(0).unwrap_or(false);
-        if !verified {
+        let status = engineer_registry_client.get_credential_status(&engineer);
+        if status != CredentialStatus::Valid && status != CredentialStatus::GracePeriod {
             panic_with_error!(&env, ContractError::UnauthorizedEngineer);
         }
         require_engineer_authorized(&env, asset_id, &engineer);
@@ -5329,9 +5331,9 @@ mod tests {
         let engineer = register_engineer(&env, &engineer_registry_client);
         client.authorize_engineer(&asset_owner, &asset_id, &engineer);
 
-        assert!(engineer_registry_client.verify_engineer(&engineer).unwrap_or(false));
+        assert_eq!(engineer_registry_client.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
         engineer_registry_client.revoke_credential(&engineer);
-        assert!(!engineer_registry_client.verify_engineer(&engineer).unwrap_or(true));
+        assert_ne!(engineer_registry_client.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         let result = client.try_submit_maintenance(
             &asset_id,
@@ -5369,7 +5371,7 @@ mod tests {
 
         // Revoke the credential
         engineer_registry_client.revoke_credential(&engineer);
-        assert_eq!(engineer_registry_client.verify_engineer(&engineer), Some(false));
+        assert_ne!(engineer_registry_client.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         // Attempt to submit maintenance ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â must fail with UnauthorizedEngineer
         let result = client.try_submit_maintenance(
@@ -5388,7 +5390,7 @@ mod tests {
         // Re-register the same engineer with a new credential hash
         let hash_v2 = BytesN::from_array(&env, &[2u8; 32]);
         engineer_registry_client.register_engineer(&engineer, &hash_v2, &issuer, &31_536_000);
-        assert_eq!(engineer_registry_client.verify_engineer(&engineer), Some(true));
+        assert_eq!(engineer_registry_client.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         // Submission must now succeed
         client.submit_maintenance(
@@ -5421,14 +5423,14 @@ mod tests {
         engineer_registry_client.register_engineer(&engineer, &hash, &issuer, &86_400);
 
         // Verify engineer is initially valid
-        assert_eq!(engineer_registry_client.verify_engineer(&engineer), Some(true));
+        assert_eq!(engineer_registry_client.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         // Advance ledger past expiry (86401 seconds)
         env.ledger()
             .with_mut(|li| li.timestamp = li.timestamp + 86_401);
 
         // Verify engineer is now expired
-        assert_eq!(engineer_registry_client.verify_engineer(&engineer), Some(false));
+        assert_ne!(engineer_registry_client.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         // Attempt submit_maintenance and assert UnauthorizedEngineer is returned
         let result = client.try_submit_maintenance(
@@ -5470,12 +5472,12 @@ mod tests {
         // Register with validity_period = 86400 seconds (minimum)
         engineer_registry_client.register_engineer(&engineer, &hash, &issuer, &86_400);
 
-        assert_eq!(engineer_registry_client.verify_engineer(&engineer), Some(true));
+        assert_eq!(engineer_registry_client.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         // Advance ledger by 101 seconds ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â credential is now expired
         env.ledger().with_mut(|li| li.timestamp += 86_401);
 
-        assert_eq!(engineer_registry_client.verify_engineer(&engineer), Some(false));
+        assert_ne!(engineer_registry_client.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         let result = client.try_submit_maintenance(
             &asset_id,
@@ -5516,12 +5518,12 @@ mod tests {
         // Register with validity_period = 86400 seconds (minimum)
         engineer_registry_client.register_engineer(&engineer, &hash, &issuer, &86_400);
 
-        assert_eq!(engineer_registry_client.verify_engineer(&engineer), Some(true));
+        assert_eq!(engineer_registry_client.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         // Advance ledger by 101 seconds ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â credential is now expired
         env.ledger().with_mut(|li| li.timestamp += 86_401);
 
-        assert_eq!(engineer_registry_client.verify_engineer(&engineer), Some(false));
+        assert_ne!(engineer_registry_client.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
@@ -5570,7 +5572,7 @@ mod tests {
             &issuer,
             &31_536_000,
         );
-        assert_eq!(engineer_registry.verify_engineer(&engineer), Some(true));
+        assert_eq!(engineer_registry.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         // 3. Submit 10 maintenance records (default score_increment = 5pts each)
         for i in 0..10u32 {
@@ -7142,7 +7144,7 @@ mod tests {
             &issuer,
             &31_536_000,
         );
-        assert_eq!(engineer_registry.verify_engineer(&engineer), Some(true));
+        assert_eq!(engineer_registry.verify_engineer(&engineer), engineer_registry::CredentialStatus::Valid);
 
         // 4. Submit maintenance ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Â 10 ÃƒÆ’Ã¢â‚¬â€ OVERHAUL (5 pts each) = 50, eligible
         for _ in 0..10 {


### PR DESCRIPTION
- Accept Valid and GracePeriod credentials in submit_maintenance and submit_maintenance_batch (7-day window after expiry)
- Add get_credential_status to lifecycle engineer_registry client trait
- Fix verify_engineer/batch_verify_engineers return types (CredentialStatus)
- Fix scrambled batch_verify/upgrade_timelock test bodies
- Remove deprecated env.invoker() calls across three contracts
- Fix frozen_score_key missing closing brace

## Summary

Describe the purpose of this pull request and the changes it introduces.

## Changes

- 
- 

## Testing

Describe how this was tested and any important validation details.

## Changelog

- [ ] I have updated `CHANGELOG.md` with this PR's changes

If this PR introduces user-facing changes, be sure to add an entry under the appropriate category (Added, Changed, Fixed, Removed, Deprecated, Security) in the `## [Unreleased]` section of `CHANGELOG.md`.

See `CONTRIBUTING.md` for changelog guidelines and examples.



closes #878 
