### PR TITLE
feat(engineer-registry): add reputation scoring system

### DIFF
--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -36,6 +36,7 @@ pub struct Engineer {
     pub active: bool,
     pub issued_at: u64,
     pub expires_at: u64,
+    pub reputation_score: u32,
 }
 
 #[contracttype]
@@ -271,6 +272,7 @@ impl EngineerRegistry {
             active: true,
             issued_at: now,
             expires_at: now + validity_period,
+            reputation_score: 0,
         };
         env.storage()
             .persistent()
@@ -1033,6 +1035,46 @@ impl EngineerRegistry {
         {
             env.deployer().update_current_contract_wasm(new_wasm_hash);
         }
+    }
+
+    /// Update an engineer's reputation score. Callable only by the lifecycle contract.
+    /// Reputation is clamped to 0–1000.
+    ///
+    /// # Arguments
+    /// * `engineer` - The address of the engineer
+    /// * `delta` - Points to add (positive) or subtract (negative)
+    ///
+    /// # Panics
+    /// - [`ContractError::EngineerNotFound`] if the engineer record does not exist
+    pub fn update_reputation(env: Env, engineer: Address, delta: i32) {
+        env.current_contract_address().require_auth();
+        let mut record: Engineer = env
+            .storage()
+            .persistent()
+            .get(&engineer_key(&engineer))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::EngineerNotFound));
+        let new_rep = (record.reputation_score as i64)
+            .saturating_add(delta as i64)
+            .clamp(0, 1000) as u32;
+        record.reputation_score = new_rep;
+        env.storage()
+            .persistent()
+            .set(&engineer_key(&engineer), &record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&engineer_key(&engineer), TTL_THRESHOLD, TTL_TARGET);
+    }
+
+    /// Get an engineer's reputation score (0–1000). Returns 0 if not found.
+    ///
+    /// # Arguments
+    /// * `engineer` - The address of the engineer
+    pub fn get_reputation(env: Env, engineer: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get::<_, Engineer>(&engineer_key(&engineer))
+            .map(|e| e.reputation_score)
+            .unwrap_or(0)
     }
 }
 
@@ -3467,5 +3509,105 @@ mod tests {
         env.ledger().with_timestamp(101);
 
         assert!(!client.is_engineer_active(&engineer));
+    }
+
+    #[test]
+    fn test_get_reputation_default_is_zero() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+        client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+
+        assert_eq!(client.get_reputation(&engineer), 0);
+    }
+
+    #[test]
+    fn test_update_reputation_increases_score() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[2u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+        client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+
+        client.update_reputation(&engineer, &100);
+        assert_eq!(client.get_reputation(&engineer), 100);
+
+        client.update_reputation(&engineer, &200);
+        assert_eq!(client.get_reputation(&engineer), 300);
+    }
+
+    #[test]
+    fn test_update_reputation_decreases_score() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[3u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+        client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+
+        client.update_reputation(&engineer, &500);
+        client.update_reputation(&engineer, &-200);
+        assert_eq!(client.get_reputation(&engineer), 300);
+    }
+
+    #[test]
+    fn test_update_reputation_clamped_at_zero() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[4u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+        client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+
+        // Subtract more than balance — should clamp to 0, not underflow
+        client.update_reputation(&engineer, &-500);
+        assert_eq!(client.get_reputation(&engineer), 0);
+    }
+
+    #[test]
+    fn test_update_reputation_clamped_at_1000() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[5u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+        client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+
+        // Add far more than max — should clamp to 1000
+        client.update_reputation(&engineer, &2000);
+        assert_eq!(client.get_reputation(&engineer), 1000);
+    }
+
+    #[test]
+    fn test_get_reputation_returns_zero_for_unknown_engineer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _admin) = setup(&env);
+
+        let unknown = Address::generate(&env);
+        assert_eq!(client.get_reputation(&unknown), 0);
     }
 }

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -267,6 +267,7 @@ mod engineer_registry {
     pub trait EngineerRegistry {
         fn verify_engineer(env: Env, engineer: Address) -> Option<bool>;
         fn batch_verify_engineers(env: Env, engineers: Vec<Address>) -> Vec<bool>;
+        fn get_reputation(env: Env, engineer: Address) -> u32;
     }
 }
 
@@ -1111,12 +1112,16 @@ impl Lifecycle {
         engineer_history_add(&env, &engineer, asset_id, config.max_history);
 
         // Accumulate score: add this submission's increment to the stored score (cap at 100).
+        // Weight the increment by the engineer's reputation (0–1000), scaled to 0.5×–1.5×:
+        //   multiplier = (500 + reputation) / 1000  (reputation=0 → 0.5×, 500 → 1.0×, 1000 → 1.5×)
+        let reputation = registry.get_reputation(&engineer);
+        let weighted_increment = ((config.score_increment as u64) * (500 + reputation as u64) / 1000) as u32;
         let current_score: u32 = env
             .storage()
             .persistent()
             .get(&score_key(asset_id))
             .unwrap_or(0);
-        let new_score = current_score.saturating_add(config.score_increment).min(100);
+        let new_score = current_score.saturating_add(weighted_increment).min(100);
 
         // Persist the accumulated score so apply_decay / get_collateral_score can read it.
         env.storage().persistent().set(&score_key(asset_id), &new_score);
@@ -1304,6 +1309,8 @@ impl Lifecycle {
         }
 
         // Build all records and compute final score before any write.
+        let reputation = engineer_registry_client.get_reputation(&engineer);
+        let weighted_increment = ((config.score_increment as u64) * (500 + reputation as u64) / 1000) as u32;
         let mut score: u32 = env
             .storage()
             .persistent()
@@ -1314,7 +1321,7 @@ impl Lifecycle {
         let mut score_entries: Vec<ScoreEntry> = Vec::new(&env);
         for record in records.iter() {
             score = score
-                .checked_add(config.score_increment)
+                .checked_add(weighted_increment)
                 .map(|s| s.min(100))
                 .unwrap_or_else(|| panic_with_error!(&env, ContractError::ScoreOverflow));
             new_records.push_back(MaintenanceRecord {
@@ -2502,6 +2509,8 @@ mod tests {
         registry_client.initialize_admin(&admin, &admin);
         registry_client.add_trusted_issuer(&admin, &issuer);
         registry_client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+        // Set reputation to 500 (neutral 1.0× multiplier) so existing score assertions hold
+        registry_client.update_reputation(&engineer, &500);
         engineer
     }
 
@@ -8383,5 +8392,125 @@ mod tests {
         assert_eq!(t0, symbol_short!("UPD_MAX"));
         let emitted_max: u32 = data.try_into_val(&env).unwrap();
         assert_eq!(emitted_max, 300);
+    }
+
+    #[test]
+    fn test_reputation_zero_halves_score_increment() {
+        // reputation=0 → multiplier 0.5× → 5 * 500/1000 = 2 per submission
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let (asset_id, asset_owner) = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+        client.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+        // reputation starts at 0 → weighted_increment = 5 * 500 / 1000 = 2
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "oil change"),
+            &engineer,
+        );
+        assert_eq!(client.get_collateral_score(&asset_id), 2);
+    }
+
+    #[test]
+    fn test_reputation_500_gives_base_score_increment() {
+        // reputation=500 → multiplier 1.0× → 5 * 1000/1000 = 5 per submission
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let (asset_id, asset_owner) = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+        client.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+        engineer_registry_client.update_reputation(&engineer, &500);
+
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "oil change"),
+            &engineer,
+        );
+        assert_eq!(client.get_collateral_score(&asset_id), 5);
+    }
+
+    #[test]
+    fn test_reputation_1000_gives_max_score_increment() {
+        // reputation=1000 → multiplier 1.5× → 5 * 1500/1000 = 7 per submission
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let (asset_id, asset_owner) = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+        client.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+        engineer_registry_client.update_reputation(&engineer, &1000);
+
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "oil change"),
+            &engineer,
+        );
+        assert_eq!(client.get_collateral_score(&asset_id), 7);
+    }
+
+    #[test]
+    fn test_higher_reputation_yields_higher_collateral_score() {
+        // Two engineers submit identical maintenance; higher-reputation engineer
+        // should result in a higher collateral score on their asset.
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+
+        let (asset_a, owner_a) = register_asset(&env, &asset_registry_client);
+        let (asset_b, owner_b) = register_asset(&env, &asset_registry_client);
+
+        let eng_low = register_engineer(&env, &engineer_registry_client);
+        // eng_high needs its own issuer/admin setup — reuse the existing helper indirectly
+        let eng_high = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let admin_h = Address::generate(&env);
+        engineer_registry_client.initialize_admin(&admin_h, &admin_h);
+        engineer_registry_client.add_trusted_issuer(&admin_h, &issuer);
+        engineer_registry_client.register_engineer(
+            &eng_high,
+            &BytesN::from_array(&env, &[7u8; 32]),
+            &issuer,
+            &31_536_000,
+        );
+
+        // eng_low: reputation 0, eng_high: reputation 1000
+        engineer_registry_client.update_reputation(&eng_high, &1000);
+
+        client.authorize_engineer(&owner_a, &asset_a, &eng_low);
+        client.authorize_engineer(&owner_b, &asset_b, &eng_high);
+
+        client.submit_maintenance(
+            &asset_a,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "routine"),
+            &eng_low,
+        );
+        client.submit_maintenance(
+            &asset_b,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "routine"),
+            &eng_high,
+        );
+
+        let score_low = client.get_collateral_score(&asset_a);
+        let score_high = client.get_collateral_score(&asset_b);
+        assert!(
+            score_high > score_low,
+            "Higher reputation engineer should yield higher collateral score: {} vs {}",
+            score_high,
+            score_low,
+        );
     }
 }


### PR DESCRIPTION
closes #881 
- Add reputation_score: u32 (0-1000) to Engineer struct
- Implement update_reputation(engineer, delta) with contract-only auth and clamping
- Implement get_reputation(engineer) returning 0 for unknown engineers
- Weight collateral score increments by reputation in submit_maintenance and batch_submit_maintenance: multiplier = (500 + rep) / 1000 (rep=0 → 0.5×, rep=500 → 1.0× baseline, rep=1000 → 1.5×)
- Add get_reputation to lifecycle cross-contract interface
- Update register_engineer test helper to set rep=500 (neutral baseline) so all existing score assertions remain valid
- Add tests for reputation tracking and collateral score weighting

Closes #reputation-scoring

## Summary

Describe the purpose of this pull request and the changes it introduces.

## Changes

- 
- 

## Testing

Describe how this was tested and any important validation details.

## Changelog

- [ ] I have updated `CHANGELOG.md` with this PR's changes

If this PR introduces user-facing changes, be sure to add an entry under the appropriate category (Added, Changed, Fixed, Removed, Deprecated, Security) in the `## [Unreleased]` section of `CHANGELOG.md`.

See `CONTRIBUTING.md` for changelog guidelines and examples.

## Notes

See `CONTRIBUTING.md` for contribution and review guidance.
