### PR TITLE
fix: resolve issues #781, #782, #783, #784

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# CODEOWNERS — required reviewers for sensitive paths.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Smart contract source: every PR touching contracts/ must be approved by a
+# contract maintainer before it can be merged.
+/contracts/ @marvs8
+
+# CI / workflow changes require the same maintainer sign-off.
+/.github/workflows/ @marvs8
+
+# Security policy and threat model are owner-gated.
+/SECURITY.md @marvs8
+/docs/threat-model.md @marvs8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `.github/CODEOWNERS`: required-reviewer rules gate all PRs touching `contracts/`, CI workflows, `SECURITY.md`, and the threat-model doc (closes [#781](https://github.com/TwinTrustMainstay/Mainstay/issues/781))
+- `CONTRIBUTING.md`: documented branch-protection requirements (1 approval + passing CI, no force-push) and the CODEOWNERS review expectation for `contracts/` (closes [#781](https://github.com/TwinTrustMainstay/Mainstay/issues/781))
+- `test_cross_owner_duplicate_serial_rejected` in `asset-registry`: verifies that the global serial-number dedup key blocks a second owner from registering the same physical machine (closes [#782](https://github.com/TwinTrustMainstay/Mainstay/issues/782))
+- `test_decay_score_never_drops_to_zero_with_history` in `lifecycle`: verifies that calling `decay_score` on an asset with maintenance records never stores or returns 0 (closes [#784](https://github.com/TwinTrustMainstay/Mainstay/issues/784))
+
+### Fixed
+- `apply_decay` in `lifecycle/src/scoring.rs`: enforce `MIN_SCORE_WITH_HISTORY = 1` in both the main decay path and the early-return path so the stored score is never written as 0 for an asset that has at least one maintenance record (closes [#784](https://github.com/TwinTrustMainstay/Mainstay/issues/784))
+
+### Security
+- `initialize_admin` in `asset-registry` already required `deployer.require_auth()`, preventing front-run attacks; the existing `test_initialize_admin_rejects_non_deployer` test and deployment-runbook section 3 now explicitly document this protection (closes [#783](https://github.com/TwinTrustMainstay/Mainstay/issues/783))
+
 ## [1.0.0] - 2026-06-02
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,23 @@ Thank you for your interest in contributing to Mainstay.
 - **Update CHANGELOG.md** with your changes (see [Changelog Updates](#changelog-updates) below).
 - Ensure secret scanning passes on PRs for `.env` and other configuration files.
 
+## Code review requirements
+
+### Branch protection on `main`
+The `main` branch is protected:
+- **At least 1 approved review** is required before merging.
+- **All CI checks must pass** (build, test, Clippy, rustfmt, cargo audit).
+- **Force pushes and branch deletion are disabled** to preserve history.
+
+### Required reviewers for contracts/
+All changes under `contracts/` — including new contracts, dependency bumps, and
+logic changes — must be approved by a code owner listed in
+[`.github/CODEOWNERS`](.github/CODEOWNERS) before merge. This rule is enforced
+automatically by GitHub's CODEOWNERS mechanism.
+
+If you are adding a new contract subdirectory, update `.github/CODEOWNERS` in
+the same PR so the new path is covered from the first commit.
+
 ## Secret scanning
 - The repository uses `gitleaks` on PRs to detect real secrets before merge.
 - The `.gitleaks.toml` configuration contains standard secret rules plus false-positive allowlists for placeholder values.

--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -1940,6 +1940,48 @@ mod tests {
         assert_ne!(id_a, id_b);
     }
 
+    /// Closes #782 — serial numbers must be globally unique: a different owner must
+    /// not be able to register an asset with the same physical serial number.
+    #[test]
+    fn test_cross_owner_duplicate_serial_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin, &admin);
+        client.add_asset_type(&admin, &symbol_short!("GENSET"));
+
+        let owner_a = Address::generate(&env);
+        let owner_b = Address::generate(&env);
+        let serial = String::from_str(&env, "SN-GLOBAL-001");
+
+        // First owner registers successfully.
+        let id = client.register_asset(
+            &symbol_short!("GENSET"),
+            &String::from_str(&env, "Machine A metadata"),
+            &serial,
+            &owner_a,
+        );
+        assert_eq!(id, 1);
+
+        // Second owner attempts to register the same physical serial — must be rejected.
+        let result = client.try_register_asset(
+            &symbol_short!("GENSET"),
+            &String::from_str(&env, "Machine A metadata different owner"),
+            &serial,
+            &owner_b,
+        );
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::DuplicateAsset as u32
+            ))),
+            "duplicate serial number must be rejected even for a different owner"
+        );
+    }
+
     #[test]
     fn test_register_asset_emits_event() {
         let env = Env::default();

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -7948,6 +7948,51 @@ mod tests {
         );
     }
 
+    /// Closes #784 — `decay_score` (which calls `apply_decay`) must also enforce
+    /// `MIN_SCORE_WITH_HISTORY`.  Before the fix, `apply_decay` could write 0 to
+    /// persistent storage for an asset that has maintenance records, making it
+    /// indistinguishable from an asset that was never maintained.
+    #[test]
+    fn test_decay_score_never_drops_to_zero_with_history() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let (asset_id, asset_owner) = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+        client.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+        // One record → raw score = DEFAULT_SCORE_INCREMENT (5).
+        client.submit_maintenance(
+            &asset_id,
+            &symbol_short!("OIL_CHG"),
+            &String::from_str(&env, "oil change"),
+            &engineer,
+        );
+        assert_eq!(client.get_collateral_score(&asset_id), 5);
+
+        // Advance time far enough for decay to fully consume the raw score.
+        // 2 × decay interval (30 days each) → total decay = 10 > 5, raw result = 0.
+        env.ledger().with_mut(|li| {
+            li.timestamp += 2 * 2_592_000; // 60 days
+        });
+
+        // Calling decay_score directly (not get_collateral_score) must also respect
+        // the floor and return 1, not 0.
+        let decayed = client.decay_score(&asset_id);
+        assert_eq!(
+            decayed, 1,
+            "decay_score must not return 0 for an asset with maintenance history"
+        );
+
+        // The value written to persistent storage must also be >= 1.
+        let stored = client.get_collateral_score(&asset_id);
+        assert_eq!(
+            stored, 1,
+            "stored collateral score must never be 0 for an asset with maintenance history"
+        );
+    }
+
     #[test]
     fn test_collateral_score_never_exceeds_maximum_with_high_volume_maintenance() {
         let env = Env::default();

--- a/contracts/lifecycle/src/scoring.rs
+++ b/contracts/lifecycle/src/scoring.rs
@@ -118,6 +118,25 @@ pub fn apply_decay(
         .unwrap_or(0u32);
 
     if current_score == 0 {
+        // Even if the stored score is already 0, apply the floor: if the asset has
+        // maintenance history it must score at least MIN_SCORE_WITH_HISTORY.
+        let zero_has_history = env
+            .storage()
+            .persistent()
+            .get::<_, Vec<MaintenanceRecord>>(&super::history_key(asset_id))
+            .map(|h: Vec<MaintenanceRecord>| !h.is_empty())
+            .unwrap_or(false);
+        if zero_has_history {
+            let floor = super::MIN_SCORE_WITH_HISTORY;
+            env.storage()
+                .persistent()
+                .set(&super::score_key(asset_id), &floor);
+            env.storage().persistent().extend_ttl(
+                &super::score_key(asset_id),
+                super::TTL_THRESHOLD,
+                super::TTL_TARGET,
+            );
+        }
         if env.storage().persistent().has(&super::last_update_key(asset_id)) {
             env.storage().persistent().extend_ttl(
                 &super::last_update_key(asset_id),
@@ -125,7 +144,11 @@ pub fn apply_decay(
                 super::TTL_TARGET,
             );
         }
-        return 0;
+        return if zero_has_history {
+            super::MIN_SCORE_WITH_HISTORY
+        } else {
+            0
+        };
     }
 
     let last_update: u64 = env
@@ -156,7 +179,23 @@ pub fn apply_decay(
     }
 
     let total_decay = (decay_intervals as u32) * config.decay_rate;
-    let new_score = current_score.saturating_sub(total_decay);
+    let raw_score = current_score.saturating_sub(total_decay);
+
+    // Enforce floor: an asset with at least one maintenance record must never score
+    // below MIN_SCORE_WITH_HISTORY (= 1) so it remains distinguishable from an asset
+    // that has never been maintained.  Check the maintenance history, not the score
+    // history, so the floor is tied to real maintenance events.
+    let has_history = env
+        .storage()
+        .persistent()
+        .get::<_, Vec<MaintenanceRecord>>(&super::history_key(asset_id))
+        .map(|h: Vec<MaintenanceRecord>| !h.is_empty())
+        .unwrap_or(false);
+    let new_score = if has_history && raw_score < super::MIN_SCORE_WITH_HISTORY {
+        super::MIN_SCORE_WITH_HISTORY
+    } else {
+        raw_score
+    };
 
     env.storage()
         .persistent()


### PR DESCRIPTION
closes #781 — Add CODEOWNERS and document branch-protection rules
- Create .github/CODEOWNERS: @marvs8 required on contracts/, .github/workflows/, SECURITY.md, and docs/threat-model.md
- Update CONTRIBUTING.md with branch-protection expectations (1 approval, CI must pass, no force-push) and CODEOWNERS review requirement for contracts/

closes #782 — Test cross-owner serial-number deduplication
- The global serial_dedup_key (SN_DEDUP) guard was already present in register_asset
- Add test_cross_owner_duplicate_serial_rejected to cover the missing test case: a second owner attempting to register the same physical serial number is rejected with ContractError::DuplicateAsset

closes #783 — Document deployer-only initialize guard (already implemented)
- initialize_admin already calls deployer.require_auth() before writing admin state
- test_initialize_admin_rejects_non_deployer already covers the attack scenario
- deployment-runbook section 3 already documents the initialize-in-same-block advice
- No code change required; issue closed by the existing implementation + tests

closes #784 — Enforce MIN_SCORE_WITH_HISTORY in apply_decay
- scoring.rs: apply_decay could write 0 to persistent storage for an asset with maintenance records, making it indistinguishable from a never-maintained asset
- Fix the main decay path: compute raw_score then clamp to MIN_SCORE_WITH_HISTORY when has_history is true before persisting
- Fix the early-return path (current_score == 0): restore the floor and correct the stored value before returning
- Add test_decay_score_never_drops_to_zero_with_history: calls decay_score directly after enough time for full decay and asserts return value and stored score >= 1

## Summary

Describe the purpose of this pull request and the changes it introduces.

## Changes

- 
- 

## Testing

Describe how this was tested and any important validation details.

## Changelog

- [ ] I have updated `CHANGELOG.md` with this PR's changes

If this PR introduces user-facing changes, be sure to add an entry under the appropriate category (Added, Changed, Fixed, Removed, Deprecated, Security) in the `## [Unreleased]` section of `CHANGELOG.md`.

See `CONTRIBUTING.md` for changelog guidelines and examples.

## Notes

See `CONTRIBUTING.md` for contribution and review guidance.
