### PR TITLE
Shared ContractError + TTL helper refactor and engineer/asset registry tests (#773, #774, #775, #776)

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -1,10 +1,14 @@
 #![no_std]
+use shared::error::SharedContractError;
 use shared::validation::{require_non_empty_vec, require_string_length};
+use shared::{extend_persistent_ttl, TTL_THRESHOLD, TTL_TARGET};
 use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, log, panic_with_error, symbol_short,
     Address, Bytes, BytesN, Env, String, Symbol, Vec,
 };
+
+pub use shared::error::SharedContractError as SharedError;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -34,6 +38,20 @@ pub enum ContractError {
     AssetAlreadyDeprecated = 17,
     /// The batch exceeds the maximum allowed size.
     BatchTooLarge = 17,
+}
+
+impl From<SharedContractError> for ContractError {
+    fn from(e: SharedContractError) -> Self {
+        match e {
+            SharedContractError::NotInitialized => ContractError::NotInitialized,
+            SharedContractError::AlreadyInitialized => ContractError::AdminAlreadyInitialized,
+            SharedContractError::UnauthorizedAdmin => ContractError::UnauthorizedAdmin,
+            SharedContractError::Paused => ContractError::Paused,
+            SharedContractError::TimelockNotExpired => ContractError::TimelockNotExpired,
+            SharedContractError::ProposalNotFound => ContractError::ProposalNotFound,
+            SharedContractError::PendingAdminAlreadyExists => ContractError::PendingAdminAlreadyExists,
+        }
+    }
 }
 
 #[contracttype]
@@ -125,10 +143,6 @@ const DECOMM_PREFIX: Symbol = symbol_short!("DECOMM");
 /// Maximum number of assets that may be registered in a single batch call.
 const MAX_BATCH_SIZE: u32 = 50;
 
-/// Soroban persistent-storage TTL constants.
-/// 1 ledger ≈ 5 seconds → 518_400 ledgers ≈ 30 days.
-const TTL_THRESHOLD: u32 = 518_400;
-const TTL_TARGET: u32 = 518_400;
 pub const DEREG_TOPIC: Symbol = symbol_short!("DEREG");
 pub const ADD_TYPE_TOPIC: Symbol = symbol_short!("ADD_TYPE");
 pub const RM_TYPE_TOPIC: Symbol = symbol_short!("RM_TYPE");
@@ -156,9 +170,7 @@ fn require_timelock_ready(env: &Env, op: Symbol, asset_id: u64) {
     }
     proposal.executed = true;
     env.storage().persistent().set(&key, &proposal);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 /// Global timelock key for admin-level operations (e.g., upgrade).
@@ -181,9 +193,7 @@ fn require_global_timelock_ready(env: &Env, op: Symbol) {
     }
     proposal.executed = true;
     env.storage().persistent().set(&key, &proposal);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 /// Decommissioned flag key: asset_id → bool.
@@ -222,7 +232,7 @@ fn type_count_inc(env: &Env, asset_type: &Symbol) {
     let key = type_count_key(asset_type);
     let count: u64 = env.storage().persistent().get(&key).unwrap_or(0);
     env.storage().persistent().set(&key, &(count + 1));
-    env.storage().persistent().extend_ttl(&key, 518400, 518400);
+    extend_persistent_ttl(&env, &key);
 }
 
 fn type_count_dec(env: &Env, asset_type: &Symbol) {
@@ -230,7 +240,7 @@ fn type_count_dec(env: &Env, asset_type: &Symbol) {
     let count: u64 = env.storage().persistent().get(&key).unwrap_or(0);
     if count > 0 {
         env.storage().persistent().set(&key, &(count - 1));
-        env.storage().persistent().extend_ttl(&key, 518400, 518400);
+        extend_persistent_ttl(&env, &key);
     }
 }
 
@@ -248,7 +258,7 @@ fn type_assets_add(env: &Env, asset_type: &Symbol, asset_id: u64) {
         .unwrap_or_else(|| Vec::new(env));
     ids.push_back(asset_id);
     env.storage().persistent().set(&key, &ids);
-    env.storage().persistent().extend_ttl(&key, 518400, 518400);
+    extend_persistent_ttl(&env, &key);
 }
 
 fn type_assets_remove(env: &Env, asset_type: &Symbol, asset_id: u64) {
@@ -265,7 +275,7 @@ fn type_assets_remove(env: &Env, asset_type: &Symbol, asset_id: u64) {
         }
     }
     env.storage().persistent().set(&key, &updated);
-    env.storage().persistent().extend_ttl(&key, 518400, 518400);
+    extend_persistent_ttl(&env, &key);
 }
 
 /// Append an asset ID to the owner's index.
@@ -278,9 +288,7 @@ fn owner_index_add(env: &Env, owner: &Address, asset_id: u64) {
         .unwrap_or_else(|| Vec::new(env));
     ids.push_back(asset_id);
     env.storage().persistent().set(&key, &ids);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 /// Remove an asset ID from the owner's index.
@@ -312,12 +320,10 @@ fn owner_index_remove(env: &Env, owner: &Address, asset_id: u64) {
         env.storage().persistent().remove(&key);
     } else {
         env.storage().persistent().set(&key, &updated);
-        env.storage().persistent().extend_ttl(&key, 518400, 518400);
+        extend_persistent_ttl(&env, &key);
     }
     env.storage().persistent().set(&key, &updated);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 /// Category index key: category bytes → Vec<u64> of asset IDs.
@@ -339,7 +345,7 @@ fn category_assets_add(env: &Env, category: &Bytes, asset_id: u64) {
         .unwrap_or_else(|| Vec::new(env));
     ids.push_back(asset_id);
     env.storage().persistent().set(&key, &ids);
-    env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 fn category_assets_remove(env: &Env, category: &Bytes, asset_id: u64) {
@@ -359,7 +365,7 @@ fn category_assets_remove(env: &Env, category: &Bytes, asset_id: u64) {
         env.storage().persistent().remove(&key);
     } else {
         env.storage().persistent().set(&key, &updated);
-        env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
     }
 }
 
@@ -377,7 +383,7 @@ fn asset_categories_add(env: &Env, asset_id: u64, category: &Bytes) {
     }
     cats.push_back(category.clone());
     env.storage().persistent().set(&key, &cats);
-    env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 fn asset_categories_remove_all(env: &Env, asset_id: u64) {
@@ -459,9 +465,7 @@ impl AssetRegistry {
                 executed: false,
             },
         );
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
     }
 
     /// Execute a previously proposed asset deregistration after the timelock expires.
@@ -532,17 +536,13 @@ impl AssetRegistry {
             deprecation_status: DeprecationStatus::Active,
         };
         env.storage().persistent().set(&asset_key(id), &asset);
-        env.storage()
-            .persistent()
-            .extend_ttl(&asset_key(id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &asset_key(id));
         env.storage().persistent().set(&ASSET_COUNT, &id);
-        env.storage()
-            .persistent()
-            .extend_ttl(&ASSET_COUNT, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &ASSET_COUNT);
         env.storage().persistent().set(&dk, &id);
-        env.storage().persistent().extend_ttl(&dk, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &dk);
         env.storage().persistent().set(&sdk, &id);
-        env.storage().persistent().extend_ttl(&sdk, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &sdk);
 
         // Update owner index
         owner_index_add(&env, &owner, id);
@@ -638,23 +638,13 @@ impl AssetRegistry {
             };
 
             env.storage().persistent().set(&asset_key(id), &asset);
-            env.storage()
-                .persistent()
-                .extend_ttl(&asset_key(id), TTL_THRESHOLD, TTL_TARGET);
+            extend_persistent_ttl(&env, &asset_key(id));
             env.storage()
                 .persistent()
                 .set(&dedup_key(&owner, &asset_in.asset_type, &meta_hash), &id);
-            env.storage().persistent().extend_ttl(
-                &dedup_key(&owner, &asset_in.asset_type, &meta_hash),
-                TTL_THRESHOLD,
-                TTL_TARGET,
-            );
+            extend_persistent_ttl(&env, &dedup_key(&owner, &asset_in.asset_type, &meta_hash));
             env.storage().persistent().set(&serial_dedup_key(&sn_hash), &id);
-            env.storage().persistent().extend_ttl(
-                &serial_dedup_key(&sn_hash),
-                TTL_THRESHOLD,
-                TTL_TARGET,
-            );
+            extend_persistent_ttl(&env, &serial_dedup_key(&sn_hash));
 
             owner_index_add(&env, &owner, id);
 
@@ -678,18 +668,12 @@ impl AssetRegistry {
 
         if next_id > env.storage().persistent().get(&ASSET_COUNT).unwrap_or(0) {
             env.storage().persistent().set(&ASSET_COUNT, &next_id);
-            env.storage()
-                .persistent()
-                .extend_ttl(&ASSET_COUNT, TTL_THRESHOLD, TTL_TARGET);
+            extend_persistent_ttl(&env, &ASSET_COUNT);
         }
 
         // Ensure owner index TTL is extended after all batch writes
         if !ids.is_empty() {
-            env.storage().persistent().extend_ttl(
-                &owner_index_key(&owner),
-                TTL_THRESHOLD,
-                TTL_TARGET,
-            );
+            extend_persistent_ttl(&env, &owner_index_key(&owner));
         }
 
         // Emit batch registration event
@@ -778,9 +762,7 @@ impl AssetRegistry {
             .get(&key)
             .unwrap_or_else(|| Vec::new(&env));
         if env.storage().persistent().has(&key) {
-            env.storage()
-                .persistent()
-                .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+            extend_persistent_ttl(&env, &key);
         }
         ids
     }
@@ -803,9 +785,7 @@ impl AssetRegistry {
             .unwrap_or_else(|| Vec::new(&env));
 
         if env.storage().persistent().has(&key) {
-            env.storage()
-                .persistent()
-                .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+            extend_persistent_ttl(&env, &key);
         }
 
         if page_size == 0 {
@@ -849,7 +829,7 @@ impl AssetRegistry {
             .get(&key)
             .unwrap_or_else(|| Vec::new(&env));
         if env.storage().persistent().has(&key) {
-            env.storage().persistent().extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+            extend_persistent_ttl(&env, &key);
         }
 
         let total = all.len();
@@ -901,7 +881,7 @@ impl AssetRegistry {
             .get(&key)
             .unwrap_or_else(|| Vec::new(&env));
         if env.storage().persistent().has(&key) {
-            env.storage().persistent().extend_ttl(&key, 518400, 518400);
+            extend_persistent_ttl(&env, &key);
         }
         ids
     }
@@ -962,7 +942,7 @@ impl AssetRegistry {
             .get(&key)
             .unwrap_or_else(|| Vec::new(&env));
         if env.storage().persistent().has(&key) {
-            env.storage().persistent().extend_ttl(&key, 518400, 518400);
+            extend_persistent_ttl(&env, &key);
         }
 
         let total = all.len();
@@ -1002,9 +982,7 @@ impl AssetRegistry {
             .get(&key)
             .unwrap_or_else(|| Vec::new(&env));
         if env.storage().persistent().has(&key) {
-            env.storage()
-                .persistent()
-                .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+            extend_persistent_ttl(&env, &key);
         }
         ids
     }
@@ -1158,9 +1136,7 @@ impl AssetRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().persistent().set(&PAUSED_KEY, &true);
-        env.storage()
-            .persistent()
-            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &PAUSED_KEY);
         env.events()
             .publish((symbol_short!("PAUSED"),), (admin.clone(),));
         env.events().publish(
@@ -1180,9 +1156,7 @@ impl AssetRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().persistent().set(&PAUSED_KEY, &false);
-        env.storage()
-            .persistent()
-            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &PAUSED_KEY);
         env.events()
             .publish((symbol_short!("UNPAUSED"),), (admin.clone(),));
         env.events().publish(
@@ -1318,15 +1292,11 @@ impl AssetRegistry {
 
         // Store new dedup key and updated asset
         env.storage().persistent().set(&new_dk, &asset_id);
-        env.storage()
-            .persistent()
-            .extend_ttl(&new_dk, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &new_dk);
         asset.metadata = new_metadata.clone();
         asset.metadata_updated_at = env.ledger().timestamp();
         env.storage().persistent().set(&asset_key(asset_id), &asset);
-        env.storage()
-            .persistent()
-            .extend_ttl(&asset_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &asset_key(asset_id));
 
         env.events().publish(
             (symbol_short!("UPD_META"), asset_id),
@@ -1374,11 +1344,7 @@ impl AssetRegistry {
         env.storage()
             .persistent()
             .set(&dedup_key(&new_owner, &asset.asset_type, &hash), &asset_id);
-        env.storage().persistent().extend_ttl(
-            &dedup_key(&new_owner, &asset.asset_type, &hash),
-            TTL_THRESHOLD,
-            TTL_TARGET,
-        );
+        extend_persistent_ttl(&env, &dedup_key(&new_owner, &asset.asset_type, &hash));
 
         // Move owner index entry
         owner_index_remove(&env, &current_owner, asset_id);
@@ -1386,9 +1352,7 @@ impl AssetRegistry {
 
         asset.owner = new_owner.clone();
         env.storage().persistent().set(&asset_key(asset_id), &asset);
-        env.storage()
-            .persistent()
-            .extend_ttl(&asset_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &asset_key(asset_id));
 
         env.events().publish(
             (symbol_short!("TRANSFER"), asset_id),
@@ -1423,7 +1387,7 @@ impl AssetRegistry {
         // Set decommissioned flag
         let decomm_key = decommissioned_key(asset_id);
         env.storage().persistent().set(&decomm_key, &true);
-        env.storage().persistent().extend_ttl(&decomm_key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &decomm_key);
 
         // Clear the under_maintenance flag when decommissioning
         let maint_key = (symbol_short!("U_MAINT"), asset_id);
@@ -1474,16 +1438,12 @@ impl AssetRegistry {
 
         asset.deprecation_status = DeprecationStatus::Deprecated;
         env.storage().persistent().set(&asset_key(asset_id), &asset);
-        env.storage()
-            .persistent()
-            .extend_ttl(&asset_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &asset_key(asset_id));
 
         // Store reason separately to avoid bloating the core Asset struct on reads.
         let reason_key = (symbol_short!("DEP_RSN"), asset_id);
         env.storage().persistent().set(&reason_key, &reason);
-        env.storage()
-            .persistent()
-            .extend_ttl(&reason_key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &reason_key);
 
         env.events().publish(
             (symbol_short!("DEPRECATED"), asset_id),
@@ -1524,15 +1484,11 @@ impl AssetRegistry {
                 executed: false,
             },
         );
-        env.storage()
-            .persistent()
-            .extend_ttl(&tl_key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &tl_key);
         env.storage()
             .persistent()
             .set(&symbol_short!("PEND_UPG"), &new_wasm_hash);
-        env.storage()
-            .persistent()
-            .extend_ttl(&symbol_short!("PEND_UPG"), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &symbol_short!("PEND_UPG"));
 
         env.events().publish(
             (symbol_short!("PROP_UPG"), admin.clone()),
@@ -1606,11 +1562,7 @@ impl AssetRegistry {
         env.storage()
             .persistent()
             .set(&asset_type_key(&asset_type), &true);
-        env.storage().persistent().extend_ttl(
-            &asset_type_key(&asset_type),
-            TTL_THRESHOLD,
-            TTL_TARGET,
-        );
+        extend_persistent_ttl(&env, &asset_type_key(&asset_type));
         env.events().publish(
             (symbol_short!("ADM_AUD"), symbol_short!("ADD_TYPE")),
             (admin, env.ledger().timestamp(), asset_type.clone()),
@@ -1730,9 +1682,7 @@ impl AssetRegistry {
 
         let decomm_key = decommissioned_key(asset_id);
         env.storage().persistent().set(&decomm_key, &true);
-        env.storage()
-            .persistent()
-            .extend_ttl(&decomm_key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &decomm_key);
 
         let maint_key = (symbol_short!("U_MAINT"), asset_id);
         env.storage().persistent().remove(&maint_key);
@@ -2513,6 +2463,54 @@ mod tests {
         // Original owner can now register the same metadata again (dedup key was moved)
         let id2 = client.register_asset(&symbol_short!("GENSET"), &metadata, &unique_serial(&env), &owner);
         assert_ne!(id, id2);
+    }
+
+    // Closes #774
+    #[test]
+    fn test_transfer_asset_updates_owner_index_and_previous_owner_can_reregister() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin, &admin);
+        client.add_asset_type(&admin, &symbol_short!("GENSET"));
+
+        let prev_owner = Address::generate(&env);
+        let new_owner = Address::generate(&env);
+        let metadata = String::from_str(&env, "CAT-3516C");
+
+        // Register with prev_owner and transfer to new_owner
+        let id = client.register_asset(&symbol_short!("GENSET"), &metadata, &unique_serial(&env), &prev_owner);
+        client.transfer_asset(&id, &prev_owner, &new_owner);
+
+        // Owner index: prev_owner no longer holds the transferred asset
+        let prev_assets = client.get_assets_by_owner(&prev_owner);
+        assert!(!prev_assets.contains(&id), "prev_owner should not appear in owner index after transfer");
+
+        // Owner index: new_owner now holds the asset
+        let new_assets = client.get_assets_by_owner(&new_owner);
+        assert!(new_assets.contains(&id), "new_owner should appear in owner index after transfer");
+
+        // prev_owner can register same metadata again (their dedup key was cleared)
+        let id2 = client.register_asset(&symbol_short!("GENSET"), &metadata, &unique_serial(&env), &prev_owner);
+        assert_ne!(id, id2, "re-registration by prev_owner should produce a new asset id");
+
+        // new_owner cannot register the same metadata (dedup key now belongs to them)
+        let dup_result = client.try_register_asset(
+            &symbol_short!("GENSET"),
+            &metadata,
+            &unique_serial(&env),
+            &new_owner,
+        );
+        assert_eq!(
+            dup_result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::DuplicateAsset as u32,
+            ))),
+            "new_owner should not be able to register the same metadata (dedup applies to new owner)",
+        );
     }
 
     #[test]

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -2847,6 +2847,48 @@ mod tests {
         assert_eq!(active.get(0).unwrap(), eng2);
     }
 
+    // Closes #776
+    #[test]
+    fn test_get_active_engineers_by_issuer_excludes_revoked_and_expired() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let issuer = Address::generate(&env);
+        let eng_valid = Address::generate(&env);
+        let eng_revoked = Address::generate(&env);
+        let eng_expired = Address::generate(&env);
+        let hash = BytesN::from_array(&env, &[2u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+
+        // Valid engineer: 1-year credential, well within the window
+        client.register_engineer(&eng_valid, &hash, &issuer, &31_536_000, &None);
+        // Revoked engineer: registered with same long validity, then immediately revoked
+        client.register_engineer(&eng_revoked, &hash, &issuer, &31_536_000, &None);
+        // Expired engineer: registered with a 1-day credential
+        client.register_engineer(&eng_expired, &hash, &issuer, &86_400, &None);
+
+        client.revoke_credential(&eng_revoked);
+
+        // Advance ledger time past the expired engineer's expiry (86_400 seconds)
+        env.ledger().set_timestamp(86_401);
+
+        // Confirm individual statuses
+        assert_eq!(client.get_engineer_status(&eng_valid), EngineerStatus::Active);
+        assert_eq!(client.get_engineer_status(&eng_revoked), EngineerStatus::Revoked);
+        assert_eq!(client.get_engineer_status(&eng_expired), EngineerStatus::Expired);
+
+        // All three remain in the full issuer list
+        let all = client.get_engineers_by_issuer(&issuer);
+        assert_eq!(all.len(), 3);
+
+        // get_active_engineers_by_issuer must return only the valid engineer
+        let active = client.get_active_engineers_by_issuer(&issuer);
+        assert_eq!(active.len(), 1);
+        assert_eq!(active.get(0).unwrap(), eng_valid);
+    }
+
     #[test]
     fn test_propose_and_accept_admin() {
         let env = Env::default();

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -1,9 +1,13 @@
 #![no_std]
+use shared::error::SharedContractError;
 use shared::validation::require_within_bounds;
+use shared::{extend_persistent_ttl, TTL_THRESHOLD, TTL_TARGET};
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
     BytesN, Env, String, Symbol, Vec,
 };
+
+pub use shared::error::SharedContractError as SharedError;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -26,6 +30,20 @@ pub enum ContractError {
     TimelockNotExpired = 15,
     ProposalNotFound = 16,
     BatchRevokeTooLarge = 17,
+}
+
+impl From<SharedContractError> for ContractError {
+    fn from(e: SharedContractError) -> Self {
+        match e {
+            SharedContractError::NotInitialized => ContractError::NotInitialized,
+            SharedContractError::AlreadyInitialized => ContractError::AdminAlreadyInitialized,
+            SharedContractError::UnauthorizedAdmin => ContractError::UnauthorizedAdmin,
+            SharedContractError::Paused => ContractError::Paused,
+            SharedContractError::TimelockNotExpired => ContractError::TimelockNotExpired,
+            SharedContractError::ProposalNotFound => ContractError::ProposalNotFound,
+            SharedContractError::PendingAdminAlreadyExists => ContractError::PendingAdminAlreadyExists,
+        }
+    }
 }
 
 #[contracttype]
@@ -88,11 +106,6 @@ const MAX_BATCH_REVOKE: u32 = 50;
 /// Grace period allowing engineers to work after credential expiry (7 days).
 const GRACE_PERIOD_SECS: u64 = 7 * 86_400;
 
-/// Soroban persistent-storage TTL constants.
-/// 1 ledger ≈ 5 seconds → 518_400 ledgers ≈ 30 days.
-const TTL_THRESHOLD: u32 = 518_400;
-const TTL_TARGET: u32 = 518_400;
-
 fn is_paused(env: &Env) -> bool {
     env.storage().persistent().get(&PAUSED_KEY).unwrap_or(false)
 }
@@ -118,9 +131,7 @@ fn require_revoke_timelock_ready(env: &Env, engineer: &Address) {
     }
     proposal.executed = true;
     env.storage().persistent().set(&key, &proposal);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 fn upgrade_timelock_key() -> (Symbol, Symbol) {
@@ -142,9 +153,7 @@ fn require_upgrade_timelock_ready(env: &Env) {
     }
     proposal.executed = true;
     env.storage().persistent().set(&key, &proposal);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 fn admin_key() -> Symbol {
@@ -200,9 +209,7 @@ impl EngineerRegistry {
                 executed: false,
             },
         );
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
     }
 
     /// Execute a pending engineer credential revocation after its timelock has expired.
@@ -284,9 +291,7 @@ impl EngineerRegistry {
         env.storage()
             .persistent()
             .set(&engineer_key(&engineer), &record);
-        env.storage()
-            .persistent()
-            .extend_ttl(&engineer_key(&engineer), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &engineer_key(&engineer));
 
         // Track issuer → engineers mapping (avoid duplicates on re-registration after revoke)
         let mut list: Vec<Address> = env
@@ -300,18 +305,12 @@ impl EngineerRegistry {
         env.storage()
             .persistent()
             .set(&issuer_engineers_key(&issuer), &list);
-        env.storage().persistent().extend_ttl(
-            &issuer_engineers_key(&issuer),
-            TTL_THRESHOLD,
-            TTL_TARGET,
-        );
+        extend_persistent_ttl(&env, &issuer_engineers_key(&issuer));
 
         // Increment engineer count
         let count: u32 = env.storage().persistent().get(&ENGINEER_COUNT).unwrap_or(0);
         env.storage().persistent().set(&ENGINEER_COUNT, &(count + 1));
-        env.storage()
-            .persistent()
-            .extend_ttl(&ENGINEER_COUNT, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &ENGINEER_COUNT);
 
         // Emit engineer registration event
         env.events().publish(
@@ -417,9 +416,7 @@ impl EngineerRegistry {
         let credential_hash = record.credential_hash.clone();
         let revoked_by = record.issuer.clone();
         // Extend TTL before write to ensure consistency even on near-expired entries
-        env.storage()
-            .persistent()
-            .extend_ttl(&engineer_key(&engineer), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &engineer_key(&engineer));
         record.active = false;
         env.storage()
             .persistent()
@@ -498,9 +495,7 @@ impl EngineerRegistry {
             renewed_at
         };
         record.expires_at = renewal_base + new_validity_period;
-        env.storage()
-            .persistent()
-            .extend_ttl(&engineer_key(&engineer), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &engineer_key(&engineer));
         env.storage()
             .persistent()
             .set(&engineer_key(&engineer), &record);
@@ -719,9 +714,7 @@ impl EngineerRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().persistent().set(&PAUSED_KEY, &true);
-        env.storage()
-            .persistent()
-            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &PAUSED_KEY);
         env.events()
             .publish((symbol_short!("PAUSED"),), (admin.clone(),));
         env.events().publish(
@@ -741,9 +734,7 @@ impl EngineerRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().persistent().set(&PAUSED_KEY, &false);
-        env.storage()
-            .persistent()
-            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &PAUSED_KEY);
         env.events()
             .publish((symbol_short!("UNPAUSED"),), (admin.clone(),));
         env.events().publish(
@@ -777,9 +768,7 @@ impl EngineerRegistry {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().persistent().set(&GRACE_PERIOD_KEY, &secs);
-        env.storage()
-            .persistent()
-            .extend_ttl(&GRACE_PERIOD_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &GRACE_PERIOD_KEY);
         env.events()
             .publish((symbol_short!("ADM_AUD"), symbol_short!("SET_GRACE")), (admin, secs));
     }
@@ -919,11 +908,7 @@ impl EngineerRegistry {
             {
                 if record.active {
                     record.active = false;
-                    env.storage().persistent().extend_ttl(
-                        &engineer_key(&engineer),
-                        TTL_THRESHOLD,
-                        TTL_TARGET,
-                    );
+                    extend_persistent_ttl(&env, &engineer_key(&engineer));
                     env.storage()
                         .persistent()
                         .set(&engineer_key(&engineer), &record);
@@ -1026,9 +1011,7 @@ impl EngineerRegistry {
             {
                 if record.active {
                     record.active = false;
-                    env.storage()
-                        .persistent()
-                        .extend_ttl(&engineer_key(&engineer), TTL_THRESHOLD, TTL_TARGET);
+                    extend_persistent_ttl(&env, &engineer_key(&engineer));
                     env.storage()
                         .persistent()
                         .set(&engineer_key(&engineer), &record);
@@ -1079,15 +1062,11 @@ impl EngineerRegistry {
                 executed: false,
             },
         );
-        env.storage()
-            .persistent()
-            .extend_ttl(&tl_key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &tl_key);
         env.storage()
             .persistent()
             .set(&symbol_short!("PEND_UPG"), &new_wasm_hash);
-        env.storage()
-            .persistent()
-            .extend_ttl(&symbol_short!("PEND_UPG"), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &symbol_short!("PEND_UPG"));
 
         env.events().publish(
             (symbol_short!("PROP_UPG"), admin.clone()),

--- a/contracts/lending/Cargo.toml
+++ b/contracts/lending/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+shared = { path = "../shared" }
 
 [dev-dependencies]
 soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/lending/src/lib.rs
+++ b/contracts/lending/src/lib.rs
@@ -1,9 +1,13 @@
 #![no_std]
 
+use shared::error::SharedContractError;
+use shared::extend_persistent_ttl;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token,
     Address, Env, Symbol, Vec,
 };
+
+pub use shared::error::SharedContractError as SharedError;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -39,6 +43,20 @@ pub enum ContractError {
     TooManyVouchers = 14,
     /// Voucher withdrawal not allowed.
     VouchWithdrawNotAllowed = 15,
+}
+
+impl From<SharedContractError> for ContractError {
+    fn from(e: SharedContractError) -> Self {
+        match e {
+            SharedContractError::NotInitialized => ContractError::NotInitialized,
+            SharedContractError::AlreadyInitialized => ContractError::AlreadyInitialized,
+            SharedContractError::UnauthorizedAdmin => ContractError::UnauthorizedAdmin,
+            SharedContractError::Paused => ContractError::ContractPaused,
+            SharedContractError::TimelockNotExpired => ContractError::NotInitialized,
+            SharedContractError::ProposalNotFound => ContractError::NotInitialized,
+            SharedContractError::PendingAdminAlreadyExists => ContractError::NotInitialized,
+        }
+    }
 }
 
 #[contracttype]
@@ -79,9 +97,6 @@ pub struct Config {
     pub yield_bps: u64,
     pub slash_bps: u64,
 }
-
-const TTL_THRESHOLD: u32 = 518_400;
-const TTL_TARGET: u32 = 518_400;
 
 /// Default yield rate numerator: 2% = 200 / 10_000.
 const DEFAULT_YIELD_NUMERATOR: u64 = 200;
@@ -208,13 +223,9 @@ impl LendingContract {
         }
 
         env.storage().persistent().set(&ADMIN_KEY, &admin);
-        env.storage()
-            .persistent()
-            .extend_ttl(&ADMIN_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &ADMIN_KEY);
         env.storage().persistent().set(&TOKEN_KEY, &token);
-        env.storage()
-            .persistent()
-            .extend_ttl(&TOKEN_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &TOKEN_KEY);
 
         // #640: Emit initialization event.
         env.events().publish(
@@ -255,9 +266,7 @@ impl LendingContract {
             deadline,
         };
         env.storage().persistent().set(&key, &loan);
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
 
         // Transfer the loan amount to the borrower
         tok.transfer(
@@ -331,9 +340,7 @@ impl LendingContract {
 
         loan.status = LoanStatus::Repaid;
         env.storage().persistent().set(&key, &loan);
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
 
         // #632: Distribute yield to vouchers from collected repayment.
         for v in vouches.iter() {
@@ -425,9 +432,7 @@ impl LendingContract {
             stake,
         });
         env.storage().persistent().set(&key, &vouches);
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
 
         let hist_key = voucher_history_key(&voucher);
         let mut history: Vec<Address> = env
@@ -437,9 +442,7 @@ impl LendingContract {
             .unwrap_or_else(|| Vec::new(&env));
         history.push_back(borrower);
         env.storage().persistent().set(&hist_key, &history);
-        env.storage()
-            .persistent()
-            .extend_ttl(&hist_key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &hist_key);
     }
 
     /// Admin-only: mark a loan as defaulted and slash based on configured rate.
@@ -469,9 +472,7 @@ impl LendingContract {
 
         loan.status = LoanStatus::Defaulted;
         env.storage().persistent().set(&key, &loan);
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
 
         let borrower_key_val = borrower_key(&borrower);
         if let Some(mut borrower_record) = env
@@ -483,9 +484,7 @@ impl LendingContract {
             env.storage()
                 .persistent()
                 .set(&borrower_key_val, &borrower_record);
-            env.storage()
-                .persistent()
-                .extend_ttl(&borrower_key_val, TTL_THRESHOLD, TTL_TARGET);
+            extend_persistent_ttl(&env, &borrower_key_val);
         }
 
         let vouches: Vec<Vouch> = env
@@ -524,9 +523,7 @@ impl LendingContract {
             .unwrap_or(0u64);
         let updated_slash = current_slash + slash_accum;
         env.storage().persistent().set(&SLASH_BAL, &updated_slash);
-        env.storage()
-            .persistent()
-            .extend_ttl(&SLASH_BAL, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &SLASH_BAL);
 
         env.events()
             .publish((LOAN_SLASHED,), (borrower.clone(), slash_accum));
@@ -555,9 +552,7 @@ impl LendingContract {
                 &(slash_balance as i128),
             );
             env.storage().persistent().set(&SLASH_BAL, &0u64);
-            env.storage()
-                .persistent()
-                .extend_ttl(&SLASH_BAL, TTL_THRESHOLD, TTL_TARGET);
+            extend_persistent_ttl(&env, &SLASH_BAL);
         }
     }
 
@@ -597,9 +592,7 @@ impl LendingContract {
 
             vouches.remove(idx);
             env.storage().persistent().set(&key, &vouches);
-            env.storage()
-                .persistent()
-                .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+            extend_persistent_ttl(&env, &key);
 
             let token_addr = get_token(&env);
             let tok = token::Client::new(&env, &token_addr);
@@ -661,9 +654,7 @@ impl LendingContract {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().persistent().set(&PAUSED_KEY, &true);
-        env.storage()
-            .persistent()
-            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &PAUSED_KEY);
         env.events()
             .publish((symbol_short!("PAUSED"),), (admin.clone(),));
     }
@@ -676,9 +667,7 @@ impl LendingContract {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().persistent().set(&PAUSED_KEY, &false);
-        env.storage()
-            .persistent()
-            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &PAUSED_KEY);
         env.events()
             .publish((symbol_short!("UNPAUSED"),), (admin.clone(),));
     }

--- a/contracts/lifecycle/src/errors.rs
+++ b/contracts/lifecycle/src/errors.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+use shared::error::SharedContractError;
 use soroban_sdk::contracterror;
 
 #[contracterror]
@@ -29,4 +30,18 @@ pub enum ContractError {
     NotesTooLong = 20,
     /// Asset score is frozen due to decommission; decay and mutation are blocked.
     ScoreFrozen = 21,
+}
+
+impl From<SharedContractError> for ContractError {
+    fn from(e: SharedContractError) -> Self {
+        match e {
+            SharedContractError::NotInitialized => ContractError::NotInitialized,
+            SharedContractError::AlreadyInitialized => ContractError::AlreadyInitialized,
+            SharedContractError::UnauthorizedAdmin => ContractError::UnauthorizedAdmin,
+            SharedContractError::Paused => ContractError::Paused,
+            SharedContractError::TimelockNotExpired => ContractError::TimelockNotExpired,
+            SharedContractError::ProposalNotFound => ContractError::ProposalNotFound,
+            SharedContractError::PendingAdminAlreadyExists => ContractError::PendingAdminAlreadyExists,
+        }
+    }
 }

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -9,11 +9,14 @@ use crate::scoring::{apply_decay, compute_decay, get_task_weight, score_history_
 use crate::types::{
     BatchRecord, Config, DataKey, HealthSnapshot, MaintenanceRecord, ScoreEntry, TimelockProposal,
 };
+use shared::extend_persistent_ttl;
 use shared::validation::require_non_empty_vec;
 use soroban_sdk::{
     contract, contractimpl, panic_with_error, symbol_short, Address, BytesN, Env, String, Symbol,
     Vec, Map,
 };
+
+pub use shared::error::SharedContractError as SharedError;
 
 const ASSET_REGISTRY: Symbol = symbol_short!("REGISTRY");
 const ENG_REGISTRY: Symbol = symbol_short!("ENG_REG");
@@ -47,11 +50,6 @@ const EVENT_XFER: Symbol = symbol_short!("XFER");
 const EVENT_PROP_ADMIN: Symbol = symbol_short!("PROP_ADM");
 const EVENT_ADMIN_SET: Symbol = symbol_short!("ADMIN_SET");
 const EVENT_PRUNED: Symbol = symbol_short!("PRUNED");
-
-/// Soroban persistent-storage TTL constants.
-/// 1 ledger ≈ 5 seconds → 518_400 ledgers ≈ 30 days.
-const TTL_THRESHOLD: u32 = 518_400;
-const TTL_TARGET: u32 = 518_400;
 
 fn history_key(asset_id: u64) -> (Symbol, u64) {
     (symbol_short!("HIST"), asset_id)
@@ -132,9 +130,7 @@ fn engineer_history_add(env: &Env, engineer: &Address, asset_id: u64, max_histor
     }
 
     env.storage().persistent().set(&key, &ids);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 fn engineer_history_remove(env: &Env, engineer: &Address, asset_id: u64) {
@@ -148,9 +144,7 @@ fn engineer_history_remove(env: &Env, engineer: &Address, asset_id: u64) {
         }
         if new_ids.len() < ids.len() {
             env.storage().persistent().set(&key, &new_ids);
-            env.storage()
-                .persistent()
-                .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+            extend_persistent_ttl(&env, &key);
         }
     }
 }
@@ -171,16 +165,12 @@ fn get_engineer_registry_addr(env: &Env) -> Address {
 
 fn set_asset_registry_addr(env: &Env, addr: &Address) {
     env.storage().persistent().set(&ASSET_REGISTRY, addr);
-    env.storage()
-        .persistent()
-        .extend_ttl(&ASSET_REGISTRY, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &ASSET_REGISTRY);
 }
 
 fn set_engineer_registry_addr(env: &Env, addr: &Address) {
     env.storage().persistent().set(&ENG_REGISTRY, addr);
-    env.storage()
-        .persistent()
-        .extend_ttl(&ENG_REGISTRY, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &ENG_REGISTRY);
 }
 
 fn is_zero_address(env: &Env, addr: &Address) -> bool {
@@ -222,9 +212,7 @@ fn store_timelock(env: &Env, op: Symbol) {
             executed: false,
         },
     );
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 fn require_timelock_ready(env: &Env, op: Symbol) {
@@ -242,9 +230,7 @@ fn require_timelock_ready(env: &Env, op: Symbol) {
     }
     proposal.executed = true;
     env.storage().persistent().set(&key, &proposal);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+    extend_persistent_ttl(&env, &key);
 }
 
 fn validate_notes_length(env: &Env, notes: &soroban_sdk::String, max: u32) {
@@ -394,9 +380,7 @@ impl Lifecycle {
 
         let key = engineer_auth_key(asset_id, &engineer);
         env.storage().persistent().set(&key, &true);
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
     }
 
     /// Revoke an engineer's owner-approved authorization for a specific asset.
@@ -432,9 +416,7 @@ impl Lifecycle {
                 executed: false,
             },
         );
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
 
         env.events().publish(
             (symbol_short!("PROP_RVK"), owner.clone()),
@@ -479,9 +461,7 @@ impl Lifecycle {
         }
         proposal.executed = true;
         env.storage().persistent().set(&key, &proposal);
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
 
         env.storage()
             .persistent()
@@ -593,9 +573,7 @@ impl Lifecycle {
             task_weights: Map::new(&env),
         };
         env.storage().persistent().set(&CONFIG, &config);
-        env.storage()
-            .persistent()
-            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &CONFIG);
 
         env.events()
             .publish((EVENT_INIT,), (asset_registry, engineer_registry, admin));
@@ -620,9 +598,7 @@ impl Lifecycle {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().persistent().set(&PAUSED_KEY, &true);
-        env.storage()
-            .persistent()
-            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &PAUSED_KEY);
         env.events()
             .publish((symbol_short!("PAUSED"),), (admin.clone(),));
         env.events().publish(
@@ -650,9 +626,7 @@ impl Lifecycle {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
         env.storage().persistent().set(&PAUSED_KEY, &false);
-        env.storage()
-            .persistent()
-            .extend_ttl(&PAUSED_KEY, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &PAUSED_KEY);
         env.events()
             .publish((symbol_short!("UNPAUSED"),), (admin.clone(),));
         env.events().publish(
@@ -723,9 +697,7 @@ impl Lifecycle {
             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
         config.admin = pending_admin.clone();
         env.storage().persistent().set(&CONFIG, &config);
-        env.storage()
-            .persistent()
-            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &CONFIG);
         env.storage().instance().remove(&PENDING_ADMIN_KEY);
         env.events().publish(
             (symbol_short!("ADM_AUD"), symbol_short!("ADMIN_SET")),
@@ -765,9 +737,7 @@ impl Lifecycle {
         let old_increment = config.score_increment;
         config.score_increment = score_increment;
         env.storage().persistent().set(&CONFIG, &config);
-        env.storage()
-            .persistent()
-            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &CONFIG);
         env.events().publish(
             (symbol_short!("CFG_UPD"),),
             (old_increment, score_increment),
@@ -827,9 +797,7 @@ impl Lifecycle {
             ),
         );
         env.storage().persistent().set(&CONFIG, &config);
-        env.storage()
-            .persistent()
-            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &CONFIG);
         env.events().publish(
             (symbol_short!("ADM_AUD"), symbol_short!("CFG_UPD")),
             (
@@ -871,9 +839,7 @@ impl Lifecycle {
         let old_threshold = config.eligibility_threshold;
         config.eligibility_threshold = threshold;
         env.storage().persistent().set(&CONFIG, &config);
-        env.storage()
-            .persistent()
-            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &CONFIG);
         env.events()
             .publish((symbol_short!("CFG_UPD"),), (old_threshold, threshold));
         env.events().publish(
@@ -923,9 +889,7 @@ impl Lifecycle {
 
         config.max_history = new_max;
         env.storage().persistent().set(&CONFIG, &config);
-        env.storage()
-            .persistent()
-            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &CONFIG);
 
         env.events()
             .publish((symbol_short!("UPD_MAX"), admin.clone()), new_max);
@@ -969,9 +933,7 @@ impl Lifecycle {
 
         config.max_notes_length = new_max;
         env.storage().persistent().set(&CONFIG, &config);
-        env.storage()
-            .persistent()
-            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &CONFIG);
 
         env.events()
             .publish((symbol_short!("UPD_NOTES"), admin.clone()), new_max);
@@ -1017,9 +979,7 @@ impl Lifecycle {
 
         config.max_notes_length = length;
         env.storage().persistent().set(&CONFIG, &config);
-        env.storage()
-            .persistent()
-            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &CONFIG);
 
         env.events()
             .publish((symbol_short!("SET_NOTES"), admin.clone()), length);
@@ -1065,9 +1025,7 @@ impl Lifecycle {
 
         config.task_weights.set(task_type.clone(), weight);
         env.storage().persistent().set(&CONFIG, &config);
-        env.storage()
-            .persistent()
-            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &CONFIG);
 
         env.events()
             .publish((symbol_short!("TSK_WT"),), (task_type.clone(), weight));
@@ -1165,9 +1123,7 @@ impl Lifecycle {
         env.storage()
             .persistent()
             .set(&history_key(asset_id), &history);
-        env.storage()
-            .persistent()
-            .extend_ttl(&history_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &history_key(asset_id));
 
         engineer_history_add(&env, &engineer, asset_id, config.max_history);
 
@@ -1181,7 +1137,7 @@ impl Lifecycle {
 
         // Persist the accumulated score so apply_decay / get_collateral_score can read it.
         env.storage().persistent().set(&score_key(asset_id), &new_score);
-        env.storage().persistent().extend_ttl(&score_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &score_key(asset_id));
 
         // Append (timestamp, score) snapshot to score history for historical tracking
         score_history_push(
@@ -1198,11 +1154,7 @@ impl Lifecycle {
         env.storage()
             .persistent()
             .set(&last_update_key(asset_id), &timestamp);
-        env.storage().persistent().extend_ttl(
-            &last_update_key(asset_id),
-            TTL_THRESHOLD,
-            TTL_TARGET,
-        );
+        extend_persistent_ttl(&env, &last_update_key(asset_id));
 
         // Emit maintenance submission event
         env.events().publish(
@@ -1286,9 +1238,7 @@ impl Lifecycle {
         env.storage()
             .persistent()
             .set(&history_key(asset_id), &history);
-        env.storage()
-            .persistent()
-            .extend_ttl(&history_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &history_key(asset_id));
 
         env.events().publish(
             (EVENT_XFER, asset_id),
@@ -1403,21 +1353,13 @@ impl Lifecycle {
         env.storage()
             .persistent()
             .set(&history_key(asset_id), &history);
-        env.storage()
-            .persistent()
-            .extend_ttl(&history_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &history_key(asset_id));
         env.storage().persistent().set(&score_key(asset_id), &score);
-        env.storage()
-            .persistent()
-            .extend_ttl(&score_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &score_key(asset_id));
         env.storage()
             .persistent()
             .set(&last_update_key(asset_id), &timestamp);
-        env.storage().persistent().extend_ttl(
-            &last_update_key(asset_id),
-            TTL_THRESHOLD,
-            TTL_TARGET,
-        );
+        extend_persistent_ttl(&env, &last_update_key(asset_id));
     }
 
     /// Apply time-based decay to an asset's collateral score.
@@ -1473,15 +1415,11 @@ impl Lifecycle {
         env.storage()
             .persistent()
             .set(&frozen_score_key(asset_id), &frozen_score);
-        env.storage()
-            .persistent()
-            .extend_ttl(&frozen_score_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &frozen_score_key(asset_id));
         env.storage()
             .persistent()
             .set(&frozen_key(asset_id), &true);
-        env.storage()
-            .persistent()
-            .extend_ttl(&frozen_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &frozen_key(asset_id));
 
         env.events()
             .publish((symbol_short!("DECOMM"), asset_id), frozen_score);
@@ -1670,15 +1608,11 @@ impl Lifecycle {
         env.storage()
             .persistent()
             .set(&score_key(asset_id), &final_score);
-        env.storage()
-            .persistent()
-            .extend_ttl(&score_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &score_key(asset_id));
         env.storage()
             .persistent()
             .set(&last_update_key(asset_id), &env.ledger().timestamp());
-        env.storage()
-            .persistent()
-            .extend_ttl(&last_update_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &last_update_key(asset_id));
         final_score
     }
 
@@ -2112,9 +2046,7 @@ impl Lifecycle {
         env.storage()
             .persistent()
             .set(&symbol_short!("PEND_UPG"), &new_wasm_hash);
-        env.storage()
-            .persistent()
-            .extend_ttl(&symbol_short!("PEND_UPG"), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &symbol_short!("PEND_UPG"));
 
         env.events().publish(
             (symbol_short!("PROP_UPG"), admin.clone()),
@@ -2196,19 +2128,13 @@ impl Lifecycle {
         // Clear the maintenance history so compute_decay returns 0 after reset.
         let empty_history: Vec<MaintenanceRecord> = Vec::new(&env);
         env.storage().persistent().set(&history_key(asset_id), &empty_history);
-        env.storage().persistent().extend_ttl(&history_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &history_key(asset_id));
         env.storage().persistent().set(&score_key(asset_id), &0u32);
-        env.storage()
-            .persistent()
-            .extend_ttl(&score_key(asset_id), TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &score_key(asset_id));
         env.storage()
             .persistent()
             .set(&last_update_key(asset_id), &now);
-        env.storage().persistent().extend_ttl(
-            &last_update_key(asset_id),
-            TTL_THRESHOLD,
-            TTL_TARGET,
-        );
+        extend_persistent_ttl(&env, &last_update_key(asset_id));
         score_history_push(
             &env,
             asset_id,
@@ -2298,9 +2224,7 @@ impl Lifecycle {
                     pruned.push_back(history.get(i).unwrap());
                 }
                 env.storage().persistent().set(&history_key, &pruned);
-                env.storage()
-                    .persistent()
-                    .extend_ttl(&history_key, TTL_THRESHOLD, TTL_TARGET);
+                extend_persistent_ttl(&env, &history_key);
 
                 // Remove asset from engineer index for engineers whose records were
                 // entirely dropped (i.e. they appear only in the pruned prefix).
@@ -2363,11 +2287,7 @@ impl Lifecycle {
                 env.storage()
                     .persistent()
                     .set(&score_history_key_val, &pruned);
-                env.storage().persistent().extend_ttl(
-                    &score_history_key_val,
-                    TTL_THRESHOLD,
-                    TTL_TARGET,
-                );
+                extend_persistent_ttl(&env, &score_history_key_val);
             }
         }
 
@@ -2530,9 +2450,7 @@ impl Lifecycle {
             .unwrap_or_else(|| Vec::new(&env));
         snapshots.push_back(snapshot.clone());
         env.storage().persistent().set(&key, &snapshots);
-        env.storage()
-            .persistent()
-            .extend_ttl(&key, TTL_THRESHOLD, TTL_TARGET);
+        extend_persistent_ttl(&env, &key);
 
         snapshot
     }

--- a/contracts/lifecycle/src/scoring.rs
+++ b/contracts/lifecycle/src/scoring.rs
@@ -21,9 +21,7 @@ pub fn score_history_push(env: &Env, asset_id: u64, entry: ScoreEntry, max_histo
         if last.timestamp == entry.timestamp {
             history.set(last_idx, entry);
             env.storage().persistent().set(&key, &history);
-            env.storage()
-                .persistent()
-                .extend_ttl(&key, super::TTL_THRESHOLD, super::TTL_TARGET);
+            shared::extend_persistent_ttl(&env, &key);
             return;
         }
     }
@@ -33,9 +31,7 @@ pub fn score_history_push(env: &Env, asset_id: u64, entry: ScoreEntry, max_histo
     }
     history.push_back(entry);
     env.storage().persistent().set(&key, &history);
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, super::TTL_THRESHOLD, super::TTL_TARGET);
+    shared::extend_persistent_ttl(&env, &key);
 }
 
 pub fn get_task_weight(env: &Env, task_type: &Symbol, config: &Config) -> u32 {
@@ -119,11 +115,7 @@ pub fn apply_decay(
 
     if current_score == 0 {
         if env.storage().persistent().has(&super::last_update_key(asset_id)) {
-            env.storage().persistent().extend_ttl(
-                &super::last_update_key(asset_id),
-                super::TTL_THRESHOLD,
-                super::TTL_TARGET,
-            );
+            shared::extend_persistent_ttl(&env, &super::last_update_key(asset_id));
         }
         return 0;
     }
@@ -144,14 +136,8 @@ pub fn apply_decay(
     let time_elapsed = current_time.saturating_sub(last_update);
     let decay_intervals = time_elapsed / config.decay_interval;
     if decay_intervals == 0 && !update_on_zero_interval {
-        env.storage()
-            .persistent()
-            .extend_ttl(&super::score_key(asset_id), super::TTL_THRESHOLD, super::TTL_TARGET);
-        env.storage().persistent().extend_ttl(
-            &super::last_update_key(asset_id),
-            super::TTL_THRESHOLD,
-            super::TTL_TARGET,
-        );
+        shared::extend_persistent_ttl(&env, &super::score_key(asset_id));
+        shared::extend_persistent_ttl(&env, &super::last_update_key(asset_id));
         return current_score;
     }
 
@@ -161,15 +147,11 @@ pub fn apply_decay(
     env.storage()
         .persistent()
         .set(&super::score_key(asset_id), &new_score);
-    env.storage()
-        .persistent()
-        .extend_ttl(&super::score_key(asset_id), super::TTL_THRESHOLD, super::TTL_TARGET);
+    shared::extend_persistent_ttl(&env, &super::score_key(asset_id));
     env.storage()
         .persistent()
         .set(&super::last_update_key(asset_id), &current_time);
-    env.storage()
-        .persistent()
-        .extend_ttl(&super::last_update_key(asset_id), super::TTL_THRESHOLD, super::TTL_TARGET);
+    shared::extend_persistent_ttl(&env, &super::last_update_key(asset_id));
 
     score_history_push(
         env,

--- a/contracts/shared/src/error.rs
+++ b/contracts/shared/src/error.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::contracterror;
+
+/// Common error variants shared across all contracts.
+///
+/// Each contract defines its own `ContractError` enum with contract-specific
+/// discriminant values. This enum captures the overlapping variants and provides
+/// a canonical mapping via `From<SharedContractError>` impls in each contract.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum SharedContractError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    UnauthorizedAdmin = 3,
+    Paused = 4,
+    TimelockNotExpired = 5,
+    ProposalNotFound = 6,
+    PendingAdminAlreadyExists = 7,
+}

--- a/contracts/shared/src/lib.rs
+++ b/contracts/shared/src/lib.rs
@@ -1,3 +1,18 @@
 #![no_std]
 
+pub mod error;
 pub mod validation;
+
+use soroban_sdk::{Env, IntoVal, Val};
+
+/// Ledger TTL threshold and target for persistent storage entries.
+/// 1 ledger ≈ 5 seconds → 518,400 ledgers ≈ 30 days.
+pub const TTL_THRESHOLD: u32 = 518_400;
+pub const TTL_TARGET: u32 = 518_400;
+
+/// Extend the TTL of a persistent storage entry using the shared threshold/target constants.
+pub fn extend_persistent_ttl<K: IntoVal<Env, Val>>(env: &Env, key: K) {
+    env.storage()
+        .persistent()
+        .extend_ttl(key, TTL_THRESHOLD, TTL_TARGET);
+}


### PR DESCRIPTION
## Summary

Bundles two smart-contract refactors and two test additions into one PR.

### Refactors
- **#773 — Shared `ContractError` base:** Added `SharedContractError` to `contracts/shared/src/error.rs` with the overlapping variants (`NotInitialized`, `AlreadyInitialized`, `UnauthorizedAdmin`, `Paused`, `TimelockNotExpired`, `ProposalNotFound`, `PendingAdminAlreadyExists`). Each contract now implements `From<SharedContractError>` for its own `ContractError` and re-exports it as `SharedError`.
- **#775 — Shared TTL helper:** Added `extend_persistent_ttl(env, key)` plus public `TTL_THRESHOLD`/`TTL_TARGET` constants (both `518_400`, matching the README) to `contracts/shared/src/lib.rs`. Replaced the inline `env.storage().persistent().extend_ttl(...)` calls across all contracts and removed the per-contract duplicate TTL constants.

### Tests
- **#776 — `get_active_engineers_by_issuer`:** Registers three engineers under one issuer (valid, revoked, expired-after-ledger-advance) and asserts only the valid engineer is returned, while `get_engineers_by_issuer` still lists all three.
- **#774 — `transfer_asset` dedup/owner index:** Registers an asset, transfers it, and asserts the previous owner's dedup key is cleared so they can re-register the same metadata, while the new owner cannot.

Closes #773
Closes #774
Closes #775
Closes #776
