### PR TITLE
test: atomic batch failure, history pagination, and deployment runbook

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -8952,4 +8952,119 @@ mod tests {
         });
         assert!(found, "SET_NOTES event not emitted");
     }
+
+    // --- Issue #770 ---
+
+    #[test]
+    fn test_batch_submit_fails_atomically_on_first_invalid_record() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let (asset_id, asset_owner) = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+        client.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+        // Two valid records followed by one invalid record (unknown task type at index 2).
+        let mut records = Vec::new(&env);
+        records.push_back(BatchRecord {
+            task_type: symbol_short!("OIL_CHG"),
+            notes: String::from_str(&env, "Valid record 0"),
+        });
+        records.push_back(BatchRecord {
+            task_type: symbol_short!("INSPECT"),
+            notes: String::from_str(&env, "Valid record 1"),
+        });
+        records.push_back(BatchRecord {
+            task_type: symbol_short!("UNKNOWN"),
+            notes: String::from_str(&env, "Invalid task type at index 2"),
+        });
+
+        let result = client.try_batch_submit_maintenance(&asset_id, &records, &engineer);
+
+        // Batch panics at the invalid record (index 2) with InvalidTaskType.
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::InvalidTaskType as u32,
+            ))),
+        );
+
+        // Atomicity guarantee: no records written despite two valid records preceding the failure.
+        assert_eq!(
+            client.get_maintenance_history(&asset_id).len(),
+            0,
+            "history must be empty — batch must not write partial records",
+        );
+        assert_eq!(
+            client.get_collateral_score(&asset_id),
+            0,
+            "score must be unchanged after a failed batch",
+        );
+    }
+
+    // --- Issue #772 ---
+
+    #[test]
+    fn test_get_maintenance_history_page_25_records() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let (asset_id, asset_owner) = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+        client.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+        // Submit 25 records in a single batch.
+        let mut records = Vec::new(&env);
+        for _ in 0..25u32 {
+            records.push_back(BatchRecord {
+                task_type: symbol_short!("OIL_CHG"),
+                notes: String::from_str(&env, "Maintenance record"),
+            });
+        }
+        client.batch_submit_maintenance(&asset_id, &records, &engineer);
+        assert_eq!(client.get_maintenance_history(&asset_id).len(), 25);
+
+        // Page 1: offset=0, limit=10 → records 0-9 (10 records).
+        let page1 = client.get_maintenance_history_page(&asset_id, &0, &10);
+        assert_eq!(page1.len(), 10, "page 1 must contain 10 records");
+
+        // Page 2: offset=10, limit=10 → records 10-19 (10 records).
+        let page2 = client.get_maintenance_history_page(&asset_id, &10, &10);
+        assert_eq!(page2.len(), 10, "page 2 must contain 10 records");
+
+        // Page 3: offset=20, limit=10 → records 20-24 (5 records, partial last page).
+        let page3 = client.get_maintenance_history_page(&asset_id, &20, &10);
+        assert_eq!(page3.len(), 5, "page 3 must contain the 5 remaining records");
+
+        // Page 4: offset=30 is beyond history length (25) → empty vec.
+        let page4 = client.get_maintenance_history_page(&asset_id, &30, &10);
+        assert_eq!(page4.len(), 0, "out-of-bounds offset must return an empty vec");
+
+        // Verify each page covers the correct slice of the full history.
+        let full = client.get_maintenance_history(&asset_id);
+        for i in 0..10u32 {
+            assert_eq!(
+                page1.get(i).unwrap().task_type,
+                full.get(i).unwrap().task_type,
+                "page1 record {} must match full history record {}",
+                i, i,
+            );
+            assert_eq!(
+                page2.get(i).unwrap().task_type,
+                full.get(10 + i).unwrap().task_type,
+                "page2 record {} must match full history record {}",
+                i, 10 + i,
+            );
+        }
+        for i in 0..5u32 {
+            assert_eq!(
+                page3.get(i).unwrap().task_type,
+                full.get(20 + i).unwrap().task_type,
+                "page3 record {} must match full history record {}",
+                i, 20 + i,
+            );
+        }
+    }
 }

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -121,3 +121,117 @@ stellar contract storage extend --id LC_ID --network testnet --durability instan
 If a contract remains inactive for long periods (near 30 days), persistent entries must be manually extended using the `stellar contract storage extend` command to prevent data loss.
 
 Refer to [docs/ttl-strategy.md](ttl-strategy.md) for a full mapping of storage keys.
+
+---
+
+## 6. Testnet vs Mainnet Differences
+
+### 6.1 Network Configuration
+
+| Aspect | Testnet | Mainnet |
+|---|---|---|
+| `--network` flag | `testnet` | `mainnet` |
+| RPC URL | `https://soroban-testnet.stellar.org` | `https://soroban-mainnet.stellar.org` (or your own node) |
+| Lumens required | Funded via Friendbot (`stellar keys fund`) | Real XLM; obtain before deployment |
+| Key management | Generated key (`stellar keys generate`) | Hardware wallet or multisig key ceremony |
+| Deployment script | `./scripts/deploy_testnet.sh` | No equivalent script; use the manual steps in this runbook with `--network mainnet` |
+
+### 6.2 Pre-Mainnet Gate: Security Audit
+
+Mainnet deployment is gated by a completed formal security audit (see §0 above). Do **not** skip this step. Before proceeding:
+
+- [ ] Audit firm has signed off on all findings.
+- [ ] Audit report is published to `docs/audit-report.md`.
+- [ ] All high- and critical-severity findings are resolved and verified.
+
+### 6.3 Mainnet Build & Deploy Steps
+
+Replace every `--network testnet` flag with `--network mainnet`. Do not use `./scripts/deploy_testnet.sh` — that script hard-rejects non-testnet networks.
+
+```bash
+# 1. Build (same as testnet)
+./scripts/build.sh
+
+# 2. Deploy Asset Registry
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/asset_registry.wasm \
+  --network mainnet \
+  --source deployer
+# Save as AR_ID
+
+# 3. Deploy Engineer Registry
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/engineer_registry.wasm \
+  --network mainnet \
+  --source deployer
+# Save as ER_ID
+
+# 4. Deploy Lifecycle (must come after AR and ER)
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/lifecycle.wasm \
+  --network mainnet \
+  --source deployer
+# Save as LC_ID
+```
+
+**Deployment order is mandatory**: Lifecycle `initialize` requires both registry contract IDs, so asset-registry and engineer-registry must be deployed and their IDs noted before lifecycle is deployed.
+
+### 6.4 Mainnet Initialization
+
+Initialize all three contracts in the **same transaction block** as deployment to eliminate front-run risk on initialization.
+
+```bash
+# Initialize Asset Registry
+stellar contract invoke --id AR_ID --network mainnet --source deployer -- initialize_admin \
+  --deployer <DEPLOYER_ADDRESS> \
+  --admin <ADMIN_ADDRESS>
+
+# Initialize Engineer Registry
+stellar contract invoke --id ER_ID --network mainnet --source deployer -- initialize_admin \
+  --deployer <DEPLOYER_ADDRESS> \
+  --admin <ADMIN_ADDRESS>
+
+# Initialize Lifecycle (bind to registries)
+stellar contract invoke --id LC_ID --network mainnet --source deployer -- initialize \
+  --deployer <DEPLOYER_ADDRESS> \
+  --asset_registry AR_ID \
+  --engineer_registry ER_ID \
+  --admin <ADMIN_ADDRESS> \
+  --max_history 200
+```
+
+### 6.5 Post-Deploy Verification Checklist
+
+Run these checks immediately after initialization. Do not hand off to operations until every item is confirmed.
+
+**Registry checks:**
+- [ ] `stellar contract invoke --id AR_ID --network mainnet --source any -- get_admin` returns the expected admin address.
+- [ ] `stellar contract invoke --id ER_ID --network mainnet --source any -- get_admin` returns the expected admin address.
+
+**Cross-contract binding check:**
+- [ ] `stellar contract invoke --id LC_ID --network mainnet --source any -- get_collateral_score --asset_id 999` returns a contract error (`AssetNotFound`), not a panic or `NotInitialized` error. A `NotInitialized` error means the binding was not saved correctly.
+
+**Config check:**
+- [ ] `stellar contract invoke --id LC_ID --network mainnet --source any -- get_config` returns `max_history: 200` and the expected admin address.
+
+**TTL extension:**
+- [ ] Extend instance storage for all three contracts immediately after initialization:
+  ```bash
+  for ID in AR_ID ER_ID LC_ID; do
+    stellar contract storage extend --id $ID --network mainnet --durability instance --ledgers-to-extend 518400
+  done
+  ```
+
+**Smoke test (optional but recommended):**
+- [ ] Register one asset type and one test asset via AR_ID.
+- [ ] Register one engineer via ER_ID.
+- [ ] Submit one maintenance record via LC_ID and confirm `get_collateral_score` returns a non-zero value.
+- [ ] Remove/deregister the test data if the contract supports it, or note the test asset IDs for auditing.
+
+### 6.6 Key Management Differences
+
+On testnet, generated keys (`stellar keys generate`) are acceptable. On mainnet:
+
+- Use a hardware wallet (Ledger) or a dedicated signing key stored in a secrets manager (e.g., HashiCorp Vault).
+- The `deployer` identity should be a cold wallet used exclusively for deployment; transfer admin rights to a multisig account before handing off to operations.
+- Store AR_ID, ER_ID, and LC_ID in a configuration management system (e.g., environment-specific `.env.mainnet`) immediately after deployment — these IDs cannot be recovered once lost without re-deployment.


### PR DESCRIPTION
## Summary

- **#770** — Add `test_batch_submit_fails_atomically_on_first_invalid_record`: submits 2 valid records followed by 1 invalid (unknown task type at index 2), asserts `InvalidTaskType` error, and asserts history and score are both 0 after the failed batch.
- **#772** — Add `test_get_maintenance_history_page_25_records`: submits 25 records via a single batch, then validates page 1 (10), page 2 (10), page 3 (5), and page 4 (0 / out-of-bounds) both for correct lengths and correct slice content against the full history.
- **#771** — Expand `docs/deployment-runbook.md` with a full §6 covering testnet/mainnet differences: a comparison table, mandatory pre-mainnet audit gate, manual mainnet deploy/init steps (with required deployment order), a post-deploy verification checklist, and mainnet key management guidance.

## Test plan

- [ ] `cargo test -p lifecycle` passes with no regressions
- [ ] `test_batch_submit_fails_atomically_on_first_invalid_record` passes
- [ ] `test_get_maintenance_history_page_25_records` passes
- [ ] Deployment runbook renders correctly in GitHub

Closes #770
Closes #771
Closes #772