### PR TITLE
feat: add set_eligibility_threshold admin function

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -1045,6 +1045,56 @@ impl Lifecycle {
         );
     }
 
+    /// Admin-only function to set the minimum lifecycle score required for collateral eligibility.
+    /// Different DeFi lenders may require different minimum scores; this allows post-deploy configuration.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin address that must match the stored config admin
+    /// * `value` - The new eligibility threshold (must be > 0)
+    ///
+    /// # Panics
+    /// - [`ContractError::NotInitialized`] if contract has not been initialized
+    /// - [`ContractError::UnauthorizedAdmin`] if caller is not the admin
+    /// - [`ContractError::InvalidConfig`] if value is 0
+    pub fn set_eligibility_threshold(env: Env, admin: Address, value: u32) {
+        ensure_not_paused(&env);
+        admin.require_auth();
+
+        if value == 0 {
+            panic_with_error!(&env, ContractError::InvalidConfig);
+        }
+
+        let mut config: Config = env
+            .storage()
+            .persistent()
+            .get(&CONFIG)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+        if config.admin != admin {
+            panic_with_error!(&env, ContractError::UnauthorizedAdmin);
+        }
+
+        let old_threshold = config.eligibility_threshold;
+        config.eligibility_threshold = value;
+        env.storage().persistent().set(&CONFIG, &config);
+        env.storage()
+            .persistent()
+            .extend_ttl(&CONFIG, TTL_THRESHOLD, TTL_TARGET);
+
+        env.events().publish(
+            (symbol_short!("SET_ELIG"), admin.clone()),
+            (old_threshold, value),
+        );
+        env.events().publish(
+            (symbol_short!("ADM_AUD"), symbol_short!("CFG_UPD")),
+            (
+                admin,
+                env.ledger().timestamp(),
+                symbol_short!("ELIG_THR"),
+                value,
+            ),
+        );
+    }
+
     /// Admin-only function to set a custom weight for a specific task type.
     /// Allows per-task-type score increment configuration. Falls back to defaults if not set.
     ///
@@ -8951,5 +9001,80 @@ mod tests {
                 && data.try_into_val::<_, u32>(&env).ok() == Some(512)
         });
         assert!(found, "SET_NOTES event not emitted");
+    }
+
+    #[test]
+    fn test_set_eligibility_threshold_updates_config() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (lifecycle, _, _, admin) = setup(&env, 0);
+
+        let initial = lifecycle.get_config().eligibility_threshold;
+        assert_eq!(initial, DEFAULT_ELIGIBILITY_THRESHOLD);
+
+        lifecycle.set_eligibility_threshold(&admin, &75);
+
+        let config = lifecycle.get_config();
+        assert_eq!(config.eligibility_threshold, 75);
+    }
+
+    #[test]
+    fn test_set_eligibility_threshold_zero_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (lifecycle, _, _, admin) = setup(&env, 0);
+
+        let result = lifecycle.try_set_eligibility_threshold(&admin, &0);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::InvalidConfig as u32,
+            ))),
+        );
+    }
+
+    #[test]
+    fn test_set_eligibility_threshold_non_admin_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (lifecycle, _, _, _admin) = setup(&env, 0);
+
+        let outsider = Address::generate(&env);
+        let result = lifecycle.try_set_eligibility_threshold(&outsider, &80);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::UnauthorizedAdmin as u32,
+            ))),
+        );
+    }
+
+    #[test]
+    fn test_set_eligibility_threshold_used_in_is_collateral_eligible() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (lifecycle, asset_registry, engineer_registry, admin) = setup(&env, 0);
+
+        let (asset_id, _owner) = register_asset(&env, &asset_registry);
+        let engineer = Address::generate(&env);
+        lifecycle.authorize_engineer(&admin, &asset_id, &engineer);
+        engineer_registry.register_engineer(&engineer, &String::from_str(&env, "Eng"));
+
+        // Submit enough maintenance records to push score above default threshold (50)
+        for _ in 0..15u32 {
+            let notes = soroban_sdk::String::from_str(&env, "maint");
+            lifecycle.submit_maintenance(&asset_id, &symbol_short!("INSPECT"), &notes, &engineer);
+        }
+
+        // With default threshold (50), asset is eligible
+        assert!(lifecycle.is_collateral_eligible(&asset_id));
+
+        // Raise threshold above current score — asset becomes ineligible
+        lifecycle.set_eligibility_threshold(&admin, &200);
+        assert!(!lifecycle.is_collateral_eligible(&asset_id));
+
+        // Lower threshold back — asset is eligible again
+        lifecycle.set_eligibility_threshold(&admin, &10);
+        assert!(lifecycle.is_collateral_eligible(&asset_id));
     }
 }


### PR DESCRIPTION
- closes #825 

Allows admin to configure the minimum lifecycle score required for collateral eligibility post-deploy. Different DeFi lenders may require different minimum scores; previously DEFAULT_ELIGIBILITY_THRESHOLD=50 was hardcoded with no setter.

## Summary

Describe the purpose of this pull request and the changes it introduces.

## Changes

- 
- 

## Testing

Describe how this was tested and any important validation details.

## Changelog

- [ ] I have updated `CHANGELOG.md` with this PR's changes

If this PR introduces user-facing changes, be sure to add an entry under the appropriate category (Added, Changed, Fixed, Removed, Deprecated, Security) in the `## [Unreleased]` section of `CHANGELOG.md`.

See `CONTRIBUTING.md` for changelog guidelines and examples.

## Notes

See `CONTRIBUTING.md` for contribution and review guidance.
