### PR TITLE
796 Fix: lifecycle batch submit maintenance loop has no upper bound DoS risk FIXED

### DIFF
--- a/contracts/lifecycle/src/errors.rs
+++ b/contracts/lifecycle/src/errors.rs
@@ -34,6 +34,8 @@ pub enum ContractError {
     AssetDecommissioned = 22,
     /// Fewer valid signers were provided than the configured admin_threshold requires.
     InsufficientSigners = 22,
+    /// Batch submission exceeds the maximum allowed batch size (DoS / gas-limit guard).
+    BatchTooLarge = 23,
 }
 
 impl From<SharedContractError> for ContractError {

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -30,6 +30,18 @@ const DEFAULT_DECAY_RATE: u32 = 5;
 const DEFAULT_DECAY_INTERVAL: u64 = 2592000; // 30 days in seconds
 const DEFAULT_ELIGIBILITY_THRESHOLD: u32 = 50;
 const DEFAULT_MAX_NOTES_LENGTH: u32 = 256;
+/// Hard cap on the number of records accepted in a single
+/// `batch_submit_maintenance` call.
+///
+/// This bounds per-transaction work to prevent a single caller from
+/// submitting an unbounded `Vec<BatchRecord>` that could blow past Soroban
+/// ledger gas/instruction limits and cause a denial-of-service. The value
+/// is intentionally conservative: maintenance batches are expected to be
+/// small (single asset, single engineer, single session), and 50 records
+/// comfortably covers realistic workflows while leaving ample headroom
+/// for the cross-contract calls and per-record validation performed
+/// inside the batch path.
+pub const MAX_BATCH_SIZE: u32 = 50;
 const TIMELOCK_DELAY_SECS: u64 = 48 * 60 * 60;
 /// Minimum score returned for an asset that has at least one maintenance record.
 /// Prevents decay from making a legitimately-maintained asset indistinguishable
@@ -1721,6 +1733,7 @@ impl Lifecycle {
     /// - [`ContractError::AssetNotFound`] if the asset does not exist
     /// - [`ContractError::UnauthorizedEngineer`] if the engineer is not verified
     /// - [`ContractError::HistoryCapReached`] if adding records would exceed max history
+    /// - [`ContractError::BatchTooLarge`] if `records.len() > MAX_BATCH_SIZE`
     pub fn batch_submit_maintenance(
         env: Env,
         asset_id: u64,
@@ -1738,6 +1751,14 @@ impl Lifecycle {
 
         // Validate records early before cross-contract calls
         require_non_empty_vec(&records, "records");
+
+        // DoS / gas-limit guard: reject unbounded batches before doing any
+        // further work (cross-contract calls, storage reads, etc.). This
+        // returns a structured `BatchTooLarge` contract error rather than
+        // letting the transaction exhaust the ledger's instruction budget.
+        if records.len() > MAX_BATCH_SIZE {
+            panic_with_error!(&env, ContractError::BatchTooLarge);
+        }
         for record in records.iter() {
             validate_notes_length(&env, &record.notes, config.max_notes_length);
             // Validate task type is known
@@ -6261,6 +6282,75 @@ mod tests {
             Err(Ok(soroban_sdk::Error::from_contract_error(
                 ContractError::InvalidTaskType as u32,
             ))),
+        );
+    }
+
+    /// Regression test: a `batch_submit_maintenance` call carrying more
+    /// than `MAX_BATCH_SIZE` records must be rejected with the structured
+    /// `BatchTooLarge` contract error, *before* any cross-contract calls
+    /// or storage writes occur. This protects the contract from a DoS
+    /// where an unbounded `Vec<BatchRecord>` could exhaust the ledger's
+    /// gas/instruction budget.
+    #[test]
+    fn test_batch_submit_maintenance_rejects_oversized_batch() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let (asset_id, asset_owner) = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+        client.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+        // Build a batch with one more record than the allowed maximum.
+        let mut records = Vec::new(&env);
+        for _ in 0..(MAX_BATCH_SIZE + 1) {
+            records.push_back(BatchRecord {
+                task_type: symbol_short!("OIL_CHG"),
+                notes: String::from_str(&env, "Oil change"),
+            });
+        }
+
+        let result = client.try_batch_submit_maintenance(&asset_id, &records, &engineer);
+
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::BatchTooLarge as u32,
+            ))),
+        );
+
+        // Confirm no partial state was written: no maintenance history,
+        // no score, no engineer history entry for this asset.
+        assert_eq!(client.get_maintenance_history(&asset_id).len(), 0);
+        assert_eq!(client.get_collateral_score(&asset_id), 0);
+    }
+
+    /// Boundary test: a batch with exactly `MAX_BATCH_SIZE` records must
+    /// be accepted (the limit is inclusive on the allowed side).
+    #[test]
+    fn test_batch_submit_maintenance_accepts_max_batch_size() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let (asset_id, asset_owner) = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+        client.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+        let mut records = Vec::new(&env);
+        for _ in 0..MAX_BATCH_SIZE {
+            records.push_back(BatchRecord {
+                task_type: symbol_short!("OIL_CHG"),
+                notes: String::from_str(&env, "Oil change"),
+            });
+        }
+
+        // Should not panic / should not return an error.
+        client.batch_submit_maintenance(&asset_id, &records, &engineer);
+
+        assert_eq!(
+            client.get_maintenance_history(&asset_id).len(),
+            MAX_BATCH_SIZE
         );
     }
 


### PR DESCRIPTION

## Summary

`Lifecycle::batch_submit_maintenance` accepted a `Vec<BatchRecord>` of unbounded length. The function then iterates that vector five separate times (validation, score computation, history push, score‑history push, event emission) and also performs cross‑contract calls into `asset-registry` and `engineer-registry`. A caller could therefore submit an arbitrarily large batch, exhaust Soroban's per‑transaction instruction budget, and cause a denial‑of‑service against the contract — burning gas with no defined error code.

This PR closes that DoS vector by enforcing a hard cap on batch size, returning a structured contract error when the cap is exceeded, and adding regression + boundary tests.

## Changes

- **`contracts/lifecycle/src/lib.rs`** — added `pub const MAX_BATCH_SIZE: u32 = 50` (documented as a per‑transaction gas guard) and a fail‑fast guard at the top of `batch_submit_maintenance` that runs **before** any cross‑contract call or storage read/write:
  ```rust
  if records.len() > MAX_BATCH_SIZE {
      panic_with_error!(&env, ContractError::BatchTooLarge);
  }
  ```
- **`contracts/lifecycle/src/errors.rs`** — added new variant `BatchTooLarge = 23` to the `#[contracterror] ContractError` enum so SDK callers receive a typed `Error::from_contract_error(23)` instead of a generic panic.
- **`contracts/lifecycle/src/lib.rs` (tests)** — added two new tests inside the existing `mod tests`:
  - `test_batch_submit_maintenance_rejects_oversized_batch` — submits `MAX_BATCH_SIZE + 1` records, asserts the call returns `Err(BatchTooLarge)` **and** that no maintenance history was written and the collateral score stayed at 0 (proves atomicity / no partial state).
  - `test_batch_submit_maintenance_accepts_max_batch_size` — boundary test confirming exactly `MAX_BATCH_SIZE` records are still accepted (the limit is inclusive on the allowed side).
- **`CHANGELOG.md`** — added a `Security` entry under `## [Unreleased]` describing the cap, the new error variant, and the new tests.

## Testing

- The two new tests reuse the exact `setup` / `register_asset` / `register_engineer` helpers and the `try_batch_submit_maintenance` + `Err(Ok(Error::from_contract_error(...)))` assertion idiom used by every other batch test in the file (`test_batch_submit_maintenance_rejects_unknown_task_type`, `test_batch_submit_no_partial_writes_on_failure`, etc.), so they are stylistically consistent with the existing suite.
- The oversized‑batch test additionally asserts post‑state — `get_maintenance_history(asset_id).len() == 0` and `get_collateral_score(asset_id) == 0` — verifying that the guard executes **before** any storage write and therefore cannot leave the contract in a partial state.
- `MAX_BATCH_SIZE = 50` is well under the `DEFAULT_MAX_HISTORY = 200` used by `setup`, so the "accepts max" boundary test cannot accidentally trip `HistoryCapReached`.
- The new `BatchTooLarge = 23` discriminant is unique among non‑duplicate variants in `ContractError`; no existing function signature, storage key, event topic, or enum value was changed.
- ⚠️ **Note on running the suite locally:** `cargo build` / `cargo test` on `main` currently fails due to several pre‑existing, unrelated issues (`tests/Cargo.toml` has three `[[test]]` blocks missing their headers around line 41; `contracts/shared/src/lib.rs::extend_persistent_ttl` passes `key` by value where SDK 22 expects `&key`; `contracts/asset-registry/src/lib.rs` has unclosed delimiters around lines 6164/6830/7966; `contracts/lifecycle/src/errors.rs` has a duplicate `= 22` discriminant for `AssetDecommissioned` and `InsufficientSigners`). These are out of scope for this PR and should be tracked separately; once they are fixed the new tests in this PR will run alongside the existing batch tests with no further changes.

## Changelog

- [x] I have updated `CHANGELOG.md` with this PR's changes

Entry added under `## [Unreleased]` → `### Security`:

> `batch_submit_maintenance` in `lifecycle`: cap batch size at the new `MAX_BATCH_SIZE = 50` constant and reject oversized batches with the new structured `ContractError::BatchTooLarge` (= 23) before any cross‑contract call or storage write, closing a DoS / gas‑exhaustion vector where an unbounded `Vec<BatchRecord>` could exceed Soroban's per‑transaction instruction limit. Adds `test_batch_submit_maintenance_rejects_oversized_batch` (verifies error + zero partial state) and `test_batch_submit_maintenance_accepts_max_batch_size` (boundary).

## Notes

- Blast radius is intentionally minimal: only additions (one constant, one enum variant, one early‑return guard, two tests, one changelog entry). No existing function signature, storage layout, event topic, or enum discriminant was modified.
- `MAX_BATCH_SIZE` is declared `pub` so off‑chain SDKs and integration tests can import the exact same limit instead of hard‑coding `50`.
- The guard is placed *after* `ensure_not_paused`, `engineer.require_auth()`, the `Config` load, and the existing `require_non_empty_vec` check, but *before* any cross‑contract call or storage read — so an attacker pays the absolute minimum gas required to be rejected.
- See `CONTRIBUTING.md` for contribution and review guidance.

CLOSE #796 