### PR TITLE
fix(engineer-registry): eliminate duplicate ContractError discriminant values

### DIFF
--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -32,8 +32,8 @@ pub enum ContractError {
     CredentialSuspended = 17,
     EngineerAlreadySuspended = 18,
     InvalidSuspensionPeriod = 19,
-    BatchRevokeTooLarge = 17,
-    CredentialExpired = 18,
+    BatchRevokeTooLarge = 20,
+    CredentialExpired = 21,
 }
 
 impl From<SharedContractError> for ContractError {


### PR DESCRIPTION
Closes #985
Closes #986
Closes #987
Closes #988

## Description

`BatchRevokeTooLarge` and `CredentialExpired` in the `ContractError` enum shared discriminant values 17 and 18 with `CredentialSuspended` and `EngineerAlreadySuspended` respectively.

This was a real bug: Soroban's `#[contracterror]` macro serializes the `#[repr(u32)]` discriminant over the wire, making the colliding variants indistinguishable on the client side.

## Changes
- `BatchRevokeTooLarge`: 17 -> 20
- `CredentialExpired`: 18 -> 21

## Verification
- All usages reference enum variants by name (not raw discriminants), so no callers break
- One test uses `ContractError::CredentialExpired as u32` which auto-adapts to the new value
- Code review confirmed the fix is correct
