### PR TITLE
Feature/priority training ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,100 @@ jobs:
 
       - name: Audit dependencies
         run: cargo audit
+
+  testnet-smoke:
+    name: Testnet Smoke Test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build WASM contracts
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Install Stellar CLI
+        run: |
+          cargo install stellar-cli --features opt
+
+      - name: Deploy to testnet
+        run: |
+          chmod +x scripts/deploy_testnet.sh
+          ./scripts/deploy_testnet.sh
+        env:
+          STELLAR_NETWORK: testnet
+
+      - name: Test register_asset round-trip
+        run: |
+          echo "Verifying asset registration on testnet..."
+          # Generate a test identity for smoke testing
+          stellar keys generate smoke-tester --network testnet
+
+          # Fund the test account on testnet (using friendbot)
+          curl "https://friendbot.stellar.org?addr=$(stellar keys address smoke-tester)"
+
+          # Get the deployed contract IDs (extracted from deploy output or stored)
+          # For now, we deploy fresh and capture IDs
+          DEPLOY_OUTPUT=$(stellar contract deploy \
+            --wasm target/wasm32-unknown-unknown/release/asset_registry.wasm \
+            --source smoke-tester \
+            --network testnet)
+          ASSET_REGISTRY_ID=$(echo "$DEPLOY_OUTPUT" | tail -1)
+          echo "Asset Registry deployed at: $ASSET_REGISTRY_ID"
+
+          # Initialize admin
+          stellar contract invoke \
+            --id "$ASSET_REGISTRY_ID" \
+            --source smoke-tester \
+            --network testnet \
+            -- initialize_admin --admin "$(stellar keys address smoke-tester)"
+
+          # Add asset type
+          stellar contract invoke \
+            --id "$ASSET_REGISTRY_ID" \
+            --source smoke-tester \
+            --network testnet \
+            -- add_asset_type --asset_type "GENSET" --admin "$(stellar keys address smoke-tester)"
+
+          # Register an asset
+          RESULT=$(stellar contract invoke \
+            --id "$ASSET_REGISTRY_ID" \
+            --source smoke-tester \
+            --network testnet \
+            -- register_asset \
+            --asset_type "GENSET" \
+            --metadata "Smoke Test Asset" \
+            --owner "$(stellar keys address smoke-tester)")
+
+          echo "Register asset result: $RESULT"
+
+          # Extract the returned asset ID and validate it
+          ASSET_ID=$(echo "$RESULT" | grep -oP '\d+' | head -1)
+          if [ -z "$ASSET_ID" ] || [ "$ASSET_ID" -le 0 ]; then
+            echo "::error::Invalid asset ID returned: $ASSET_ID"
+            exit 1
+          fi
+          echo "Successfully registered asset with ID: $ASSET_ID"
+
+          # Store deployed contract IDs as artifacts
+          echo "ASSET_REGISTRY_ID=$ASSET_REGISTRY_ID" >> contract-ids.env
+          echo "ASSET_ID=$ASSET_ID" >> contract-ids.env
+
+      - name: Upload contract IDs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: contract-ids
+          path: contract-ids.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,56 @@ jobs:
       - name: Run workspace tests
         run: cargo test --workspace
 
+  wasm-size:
+    name: WASM Size Check
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Build WASM contracts
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Check WASM sizes
+        run: |
+          # Soroban maximum WASM size is 65536 bytes
+          # Threshold set at 80% (52428 bytes) to leave headroom
+          MAX_SIZE=52428
+          THRESHOLD_PCT=80
+
+          echo "Checking WASM binary sizes against ${THRESHOLD_PCT}% of Soroban max (${MAX_SIZE} bytes)..."
+
+          EXCEEDED=0
+          for wasm in target/wasm32-unknown-unknown/release/*.wasm; do
+            SIZE=$(stat -c%s "$wasm" 2>/dev/null || stat -f%z "$wasm" 2>/dev/null)
+            NAME=$(basename "$wasm")
+            echo "  ${NAME}: ${SIZE} bytes"
+            if [ "$SIZE" -gt "$MAX_SIZE" ]; then
+              echo "::error file=${wasm}::${NAME} is ${SIZE} bytes, exceeding the ${MAX_SIZE} byte threshold"
+              EXCEEDED=1
+            fi
+          done
+
+          if [ "$EXCEEDED" -eq 1 ]; then
+            echo "::error::One or more WASM binaries exceed the size threshold"
+            exit 1
+          fi
+          echo "All WASM binaries are within the size limit."
+
   audit:
     name: Dependency Audit
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Mainstay — Proof of Maintenance for Industrial Assets
 
 [![CI](https://github.com/marvs8/Mainstay/actions/workflows/ci.yml/badge.svg)](https://github.com/marvs8/Mainstay/actions/workflows/ci.yml)
+[![WASM Size](https://img.shields.io/badge/WASM%20size-%E2%89%A4%2051%20KB-brightgreen)](https://github.com/marvs8/Mainstay/actions/workflows/ci.yml)
 [![Clippy](https://img.shields.io/badge/clippy-passing-brightgreen)](https://github.com/marvs8/Mainstay/actions/workflows/ci.yml)
 [![rustfmt](https://img.shields.io/badge/rustfmt-passing-brightgreen)](https://github.com/marvs8/Mainstay/actions/workflows/ci.yml)
 [![cargo audit](https://img.shields.io/badge/cargo%20audit-high--severity%20gate-blue)](https://github.com/marvs8/Mainstay/actions/workflows/ci.yml)

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -37,6 +37,15 @@ pub struct Engineer {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TrainingRecord {
+    pub training_type: Symbol,
+    pub completion_date: u64,
+    pub certificate_hash: BytesN<32>,
+    pub issuer: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EngineerStatus {
     Active = 0,
     Revoked = 1,
@@ -78,6 +87,10 @@ fn trusted_key(issuer: &Address) -> (Symbol, Address) {
 
 fn issuer_engineers_key(issuer: &Address) -> (Symbol, Address) {
     (symbol_short!("ISS_ENGS"), issuer.clone())
+}
+
+fn training_key(engineer: &Address) -> (Symbol, Address) {
+    (symbol_short!("TRAIN"), engineer.clone())
 }
 
 /// Returns the key for the authoritative trusted-issuer list in instance storage.
@@ -609,6 +622,79 @@ impl EngineerRegistry {
     /// Get the number of engineers credentialed by a specific issuer.
     pub fn get_engineer_count_by_issuer(env: Env, issuer: Address) -> u32 {
         Self::get_engineers_by_issuer(env, issuer).len()
+    }
+
+    /// Record a training completion for an engineer.
+    /// Only the engineer's original credential issuer can record training.
+    ///
+    /// # Arguments
+    /// * `engineer` - The address of the engineer who completed the training
+    /// * `training_type` - Symbol identifying the type of training completed
+    /// * `completion_date` - Unix timestamp when training was completed
+    /// * `certificate_hash` - Hash of the training certificate/documentation
+    ///
+    /// # Panics
+    /// - [`ContractError::EngineerNotFound`] if no engineer exists with the given address
+    /// - [`ContractError::UntrustedIssuer`] if the caller is not the engineer's issuer or not trusted
+    pub fn record_training(
+        env: Env,
+        engineer: Address,
+        training_type: Symbol,
+        completion_date: u64,
+        certificate_hash: BytesN<32>,
+    ) {
+        ensure_not_paused(&env);
+
+        let engineer_record: Engineer = env
+            .storage()
+            .persistent()
+            .get(&engineer_key(&engineer))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::EngineerNotFound));
+
+        engineer_record.issuer.require_auth();
+
+        // Verify the caller is still a trusted issuer
+        if !env.storage().instance().has(&trusted_key(&engineer_record.issuer)) {
+            panic_with_error!(&env, ContractError::UntrustedIssuer);
+        }
+
+        let record = TrainingRecord {
+            training_type: training_type.clone(),
+            completion_date,
+            certificate_hash: certificate_hash.clone(),
+            issuer: engineer_record.issuer.clone(),
+        };
+
+        let key = training_key(&engineer);
+        let mut history: Vec<TrainingRecord> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(&env));
+        history.push_back(record);
+        env.storage().persistent().set(&key, &history);
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, 518400, 518400);
+
+        env.events().publish(
+            (symbol_short!("REC_TRAIN"), engineer.clone()),
+            (training_type, completion_date, certificate_hash),
+        );
+    }
+
+    /// Get the complete training history for an engineer.
+    ///
+    /// # Arguments
+    /// * `engineer` - The address of the engineer
+    ///
+    /// # Returns
+    /// Vec of TrainingRecord containing all training records in chronological order
+    pub fn get_training_history(env: Env, engineer: Address) -> Vec<TrainingRecord> {
+        env.storage()
+            .persistent()
+            .get(&training_key(&engineer))
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     /// Admin-only function to upgrade the contract WASM to a new hash.
@@ -2355,5 +2441,113 @@ mod tests {
                 ContractError::Paused as u32
             )))
         );
+    }
+
+    // --- Training record tests ---
+
+    #[test]
+    fn test_record_training_and_get_history() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let cred_hash = BytesN::from_array(&env, &[1u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+        client.register_engineer(&engineer, &cred_hash, &issuer, &31_536_000);
+
+        let cert_hash = BytesN::from_array(&env, &[9u8; 32]);
+        let ts = env.ledger().timestamp();
+        client.record_training(&engineer, &symbol_short!("SAFETY"), &ts, &cert_hash);
+
+        let history = client.get_training_history(&engineer);
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).unwrap().training_type, symbol_short!("SAFETY"));
+        assert_eq!(history.get(0).unwrap().completion_date, ts);
+        assert_eq!(history.get(0).unwrap().certificate_hash, cert_hash);
+        assert_eq!(history.get(0).unwrap().issuer, issuer);
+    }
+
+    #[test]
+    fn test_record_training_multiple_entries() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let cred_hash = BytesN::from_array(&env, &[1u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+        client.register_engineer(&engineer, &cred_hash, &issuer, &31_536_000);
+
+        client.record_training(&engineer, &symbol_short!("SAFETY"), &env.ledger().timestamp(), &BytesN::from_array(&env, &[1u8; 32]));
+        client.record_training(&engineer, &symbol_short!("TECHNICAL"), &env.ledger().timestamp(), &BytesN::from_array(&env, &[2u8; 32]));
+        client.record_training(&engineer, &symbol_short!("COMPLIANCE"), &env.ledger().timestamp(), &BytesN::from_array(&env, &[3u8; 32]));
+
+        let history = client.get_training_history(&engineer);
+        assert_eq!(history.len(), 3);
+    }
+
+    #[test]
+    fn test_get_training_history_empty() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let history = client.get_training_history(&engineer);
+        assert_eq!(history.len(), 0);
+    }
+
+    #[test]
+    fn test_record_training_unknown_engineer_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+
+        let unknown = Address::generate(&env);
+        let cert_hash = BytesN::from_array(&env, &[1u8; 32]);
+        let result = client.try_record_training(&unknown, &symbol_short!("SAFETY"), &env.ledger().timestamp(), &cert_hash);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::EngineerNotFound as u32,
+            ))),
+        );
+    }
+
+    #[test]
+    fn test_record_training_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin) = setup(&env);
+
+        let engineer = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let cred_hash = BytesN::from_array(&env, &[1u8; 32]);
+
+        client.add_trusted_issuer(&admin, &issuer);
+        client.register_engineer(&engineer, &cred_hash, &issuer, &31_536_000);
+
+        let cert_hash = BytesN::from_array(&env, &[5u8; 32]);
+        let ts = env.ledger().timestamp();
+        client.record_training(&engineer, &symbol_short!("SAFETY"), &ts, &cert_hash);
+
+        let events = env.events().all();
+        let (_, topics, data) = events.last().unwrap();
+        use soroban_sdk::TryIntoVal;
+        let t0: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+        let t1: Address = topics.get(1).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(t0, symbol_short!("REC_TRAIN"));
+        assert_eq!(t1, engineer);
+
+        let (emitted_type, emitted_date, emitted_hash): (Symbol, u64, BytesN<32>) =
+            data.try_into_val(&env).unwrap();
+        assert_eq!(emitted_type, symbol_short!("SAFETY"));
+        assert_eq!(emitted_date, ts);
+        assert_eq!(emitted_hash, cert_hash);
     }
 }

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -25,10 +25,20 @@ pub enum ContractError {
 }
 
 #[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Priority {
+    Critical = 0,
+    High = 1,
+    Medium = 2,
+    Low = 3,
+}
+
+#[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MaintenanceRecord {
     pub asset_id: u64,
     pub task_type: Symbol,
+    pub priority: Priority,
     pub notes: String,
     pub engineer: Address,
     pub timestamp: u64,
@@ -46,6 +56,7 @@ pub struct ScoreEntry {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BatchRecord {
     pub task_type: Symbol,
+    pub priority: Priority,
     pub notes: String,
 }
 
@@ -82,6 +93,7 @@ const EVENT_RST_SCR: Symbol = symbol_short!("RST_SCR");
 const EVENT_XFER: Symbol = symbol_short!("XFER");
 const EVENT_PROP_ADMIN: Symbol = symbol_short!("PROP_ADM");
 const EVENT_ADMIN_SET: Symbol = symbol_short!("ADMIN_SET");
+const EVENT_CRIT_OVRD: Symbol = symbol_short!("CRIT_OVRD");
 
 fn history_key(asset_id: u64) -> (Symbol, u64) {
     (symbol_short!("HIST"), asset_id)
@@ -775,6 +787,7 @@ impl Lifecycle {
         env: Env,
         asset_id: u64,
         task_type: Symbol,
+        priority: Priority,
         notes: String,
         engineer: Address,
     ) {
@@ -818,6 +831,7 @@ impl Lifecycle {
         let record = MaintenanceRecord {
             asset_id,
             task_type: task_type.clone(),
+            priority,
             notes,
             engineer: engineer.clone(),
             timestamp,
@@ -868,7 +882,7 @@ impl Lifecycle {
 
         // Emit maintenance submission event
         env.events()
-            .publish((EVENT_MAINT, asset_id), (task_type, engineer, timestamp));
+            .publish((EVENT_MAINT, asset_id), (task_type, priority, engineer, timestamp));
     }
 
     /// Record an ownership transfer in the asset's maintenance history.
@@ -906,6 +920,7 @@ impl Lifecycle {
         let sentinel = MaintenanceRecord {
             asset_id,
             task_type: symbol_short!("XFER"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Ownership transferred"),
             engineer: new_owner.clone(),
             timestamp,
@@ -1005,6 +1020,7 @@ impl Lifecycle {
             history.push_back(MaintenanceRecord {
                 asset_id,
                 task_type: record.task_type.clone(),
+                priority: record.priority,
                 notes: record.notes.clone(),
                 engineer: engineer.clone(),
                 timestamp,
@@ -1017,7 +1033,7 @@ impl Lifecycle {
             );
             env.events().publish(
                 (EVENT_MAINT, asset_id),
-                (record.task_type.clone(), engineer.clone(), timestamp),
+                (record.task_type.clone(), record.priority, engineer.clone(), timestamp),
             );
         }
 
@@ -1082,6 +1098,91 @@ impl Lifecycle {
             .persistent()
             .get(&history_key(asset_id))
             .unwrap_or(Vec::new(&env))
+    }
+
+    /// Get overdue maintenance tasks for an asset.
+    ///
+    /// Returns all maintenance records older than `days_overdue` days from the
+    /// current ledger timestamp. If any of the overdue tasks have `Priority::Critical`,
+    /// a `CRIT_OVRD` event is emitted to alert operations teams.
+    ///
+    /// # Arguments
+    /// * `asset_id` - The unique identifier of the asset
+    /// * `days_overdue` - Number of days past which a task is considered overdue
+    ///
+    /// # Returns
+    /// Vec of overdue MaintenanceRecords
+    ///
+    /// # Panics
+    /// - [`ContractError::NotInitialized`] if contract has not been initialized
+    /// - [`ContractError::AssetNotFound`] if no asset exists with the given ID
+    pub fn get_overdue_tasks(env: Env, asset_id: u64, days_overdue: u64) -> Vec<MaintenanceRecord> {
+        let asset_registry = get_asset_registry_addr(&env);
+        verify_asset_exists(&env, &asset_registry, &asset_id);
+
+        let history: Vec<MaintenanceRecord> = env
+            .storage()
+            .persistent()
+            .get(&history_key(asset_id))
+            .unwrap_or(Vec::new(&env));
+
+        let now = env.ledger().timestamp();
+        let cutoff = now.saturating_sub(days_overdue.saturating_mul(86400));
+
+        let mut overdue = Vec::new(&env);
+        let mut has_critical = false;
+        for record in history.iter() {
+            if record.timestamp < cutoff {
+                if record.priority == Priority::Critical {
+                    has_critical = true;
+                }
+                overdue.push_back(record);
+            }
+        }
+
+        if has_critical {
+            env.events()
+                .publish((EVENT_CRIT_OVRD, asset_id), (days_overdue, overdue.len()));
+        }
+
+        overdue
+    }
+
+    /// Get maintenance tasks filtered by priority level.
+    ///
+    /// Returns all maintenance records for the asset that match the given priority.
+    ///
+    /// # Arguments
+    /// * `asset_id` - The unique identifier of the asset
+    /// * `priority` - The priority level to filter by
+    ///
+    /// # Returns
+    /// Vec of MaintenanceRecords matching the specified priority
+    ///
+    /// # Panics
+    /// - [`ContractError::NotInitialized`] if contract has not been initialized
+    /// - [`ContractError::AssetNotFound`] if no asset exists with the given ID
+    pub fn get_tasks_by_priority(
+        env: Env,
+        asset_id: u64,
+        priority: Priority,
+    ) -> Vec<MaintenanceRecord> {
+        let asset_registry = get_asset_registry_addr(&env);
+        verify_asset_exists(&env, &asset_registry, &asset_id);
+
+        let history: Vec<MaintenanceRecord> = env
+            .storage()
+            .persistent()
+            .get(&history_key(asset_id))
+            .unwrap_or(Vec::new(&env));
+
+        let mut result = Vec::new(&env);
+        for record in history.iter() {
+            if record.priority == priority {
+                result.push_back(record);
+            }
+        }
+        result
     }
 
     /// Get a paginated slice of the maintenance history for an asset.
@@ -1782,6 +1883,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "Routine oil change"),
                 &engineer,
             );
@@ -1817,6 +1919,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &999u64,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Should fail"),
             &engineer,
         );
@@ -1842,6 +1945,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "ok"),
                 &engineer,
             );
@@ -1850,6 +1954,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "over cap"),
             &engineer,
         );
@@ -1876,6 +1981,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "ok"),
                 &engineer,
             );
@@ -1887,6 +1993,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "over cap"),
             &unregistered,
         );
@@ -1934,6 +2041,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &asset_id,
             &symbol_short!("UNKNOWN"),
+            &Priority::Low,
             &String::from_str(&env, "Unknown task type"),
             &engineer,
         );
@@ -1984,6 +2092,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Should fail"),
             &unregistered,
         );
@@ -2008,12 +2117,14 @@ mod tests {
         client.submit_maintenance(
             &asset_id1,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "one"),
             &engineer,
         );
         client.submit_maintenance(
             &asset_id2,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "two"),
             &engineer,
         );
@@ -2043,6 +2154,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "service"),
                 &engineer,
             );
@@ -2078,12 +2190,14 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "first"),
             &engineer,
         );
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("INSPECT"),
+            &Priority::Low,
             &String::from_str(&env, "second"),
             &engineer,
         );
@@ -2126,6 +2240,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "first"),
             &engineer,
         );
@@ -2135,6 +2250,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("INSPECT"),
+            &Priority::Low,
             &String::from_str(&env, "second"),
             &engineer,
         );
@@ -2157,6 +2273,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Configured increment"),
             &engineer,
         );
@@ -2178,6 +2295,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "First"),
             &engineer,
         );
@@ -2188,6 +2306,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("FILTER"),
+            &Priority::Low,
             &String::from_str(&env, "Second"),
             &engineer,
         );
@@ -2200,6 +2319,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("ENGINE"),
+                &Priority::Low,
                 &String::from_str(&env, "Bulk"),
                 &engineer,
             );
@@ -2318,6 +2438,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "Maintenance"),
                 &engineer,
             );
@@ -2335,6 +2456,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Maintenance"),
             &engineer,
         );
@@ -2367,6 +2489,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "Maintenance"),
                 &engineer,
             );
@@ -2411,6 +2534,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "Maintenance"),
                 &engineer,
             );
@@ -2480,6 +2604,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Major overhaul"),
             &engineer,
         );
@@ -2573,6 +2698,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("ENGINE"),
+                &Priority::Low,
                 &String::from_str(&env, "Major work"),
                 &engineer,
             );
@@ -2608,6 +2734,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("ENGINE"),
+                &Priority::Low,
                 &String::from_str(&env, "Build score"),
                 &engineer,
             );
@@ -2645,6 +2772,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("ENGINE"),
+                &Priority::Low,
                 &String::from_str(&env, "Build score"),
                 &engineer,
             );
@@ -2693,6 +2821,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("ENGINE"),
+                &Priority::Low,
                 &String::from_str(&env, "Build score to 50"),
                 &engineer,
             );
@@ -2719,6 +2848,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Single major service"),
             &engineer,
         );
@@ -2779,6 +2909,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, ""),
             &engineer,
         );
@@ -2813,6 +2944,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, ""),
             &engineer,
         );
@@ -2859,6 +2991,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Routine"),
             &engineer,
         );
@@ -2974,6 +3107,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "notes"),
             &engineer,
         );
@@ -2993,6 +3127,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "notes"),
             &engineer,
         );
@@ -3018,6 +3153,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("FILTER"),
+                &Priority::Low,
                 &String::from_str(&env, "notes"),
                 &engineer,
             );
@@ -3048,6 +3184,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("FILTER"),
+            &Priority::Low,
             &String::from_str(&env, "Filter replacement 1"),
             &engineer,
         );
@@ -3058,6 +3195,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("FILTER"),
+            &Priority::Low,
             &String::from_str(&env, "Filter replacement 2"),
             &engineer,
         );
@@ -3112,6 +3250,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_a,
                 &symbol_short!("ENGINE"),
+                &Priority::Low,
                 &String::from_str(&env, ""),
                 &engineer,
             );
@@ -3122,6 +3261,7 @@ mod tests {
         client.submit_maintenance(
             &asset_b,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, ""),
             &engineer,
         );
@@ -3182,12 +3322,14 @@ mod tests {
             client.submit_maintenance(
                 &asset_a,
                 &symbol_short!("ENGINE"),
+                &Priority::Low,
                 &String::from_str(&env, ""),
                 &engineer,
             );
             client.submit_maintenance(
                 &asset_b,
                 &symbol_short!("ENGINE"),
+                &Priority::Low,
                 &String::from_str(&env, ""),
                 &engineer,
             );
@@ -3401,18 +3543,21 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "First"),
             &engineer,
         );
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Second"),
             &engineer,
         );
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("FILTER"),
+            &Priority::Low,
             &String::from_str(&env, "Third"),
             &engineer,
         );
@@ -3435,18 +3580,21 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "a"),
             &engineer,
         );
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "b"),
             &engineer,
         );
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("FILTER"),
+            &Priority::Low,
             &String::from_str(&env, "c"),
             &engineer,
         );
@@ -3470,6 +3618,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "at t0"),
             &engineer,
         );
@@ -3480,6 +3629,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("LUBE"),
+            &Priority::Low,
             &String::from_str(&env, "at t1"),
             &engineer,
         );
@@ -3503,6 +3653,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("REBUILD"),
+                &Priority::Low,
                 &String::from_str(&env, "major"),
                 &engineer,
             );
@@ -3533,6 +3684,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, ""),
                 &engineer,
             );
@@ -3565,6 +3717,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "entry"),
                 &engineer,
             );
@@ -3591,6 +3744,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "only one"),
             &engineer,
         );
@@ -3612,6 +3766,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "entry"),
             &engineer,
         );
@@ -3644,14 +3799,17 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Oil change"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("INSPECT"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Inspection"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("ENGINE"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Engine repair"),
         });
 
@@ -3674,10 +3832,12 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Oil change"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("INSPECT"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Inspection"),
         });
 
@@ -3707,6 +3867,7 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("UNKNOWN"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Unknown task type"),
         });
 
@@ -3733,14 +3894,17 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Oil change 1"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Oil change 2"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("INSPECT"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Inspection"),
         });
 
@@ -3766,6 +3930,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, ""),
                 &engineer,
             );
@@ -3776,10 +3941,12 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, ""),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, ""),
         });
 
@@ -3807,14 +3974,17 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "First"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Second"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Third - over cap"),
         });
 
@@ -3839,6 +4009,7 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Should fail"),
         });
 
@@ -3863,14 +4034,17 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Valid"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("INSPECT"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Valid"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("UNKNOWN"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Invalid task type"),
         });
 
@@ -3897,6 +4071,7 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, &"x".repeat(300)),
         });
 
@@ -3922,6 +4097,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Should fail"),
             &unregistered,
         );
@@ -3947,6 +4123,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("FILTER"),
+                &Priority::Low,
                 &String::from_str(&env, "Filter replacement"),
                 &engineer,
             );
@@ -3969,6 +4146,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Post-revocation attempt"),
             &engineer,
         );
@@ -4007,6 +4185,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Post-revocation attempt"),
             &engineer,
         );
@@ -4026,6 +4205,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Post-reregistration submission"),
             &engineer,
         );
@@ -4066,6 +4246,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Post-expiry attempt"),
             &engineer,
         );
@@ -4088,6 +4269,7 @@ mod tests {
         let owner = Address::generate(&env);
         let asset_id = asset_registry_client.register_asset(
             &symbol_short!("GENSET"),
+            &Priority::Low,
             &String::from_str(&env, "Test Generator"),
             &owner,
         );
@@ -4111,6 +4293,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Post-expiry attempt"),
             &engineer,
         );
@@ -4133,6 +4316,7 @@ mod tests {
         let owner = Address::generate(&env);
         let asset_id = asset_registry_client.register_asset(
             &symbol_short!("GENSET"),
+            &Priority::Low,
             &String::from_str(&env, "Test Generator"),
             &owner,
         );
@@ -4156,6 +4340,7 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Post-expiry batch attempt"),
         });
 
@@ -4206,6 +4391,7 @@ mod tests {
             lifecycle.submit_maintenance(
                 &asset_id,
                 &symbol_short!("ENGINE"),
+                &Priority::Low,
                 &String::from_str(&env, "Full engine service"),
                 &engineer,
             );
@@ -4237,6 +4423,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, ""),
             &engineer,
         );
@@ -4281,6 +4468,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Major overhaul"),
             &engineer,
         );
@@ -4303,6 +4491,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Major overhaul"),
             &engineer,
         );
@@ -4330,6 +4519,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Major overhaul"),
             &engineer,
         );
@@ -4339,6 +4529,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Post-reset work"),
             &engineer,
         );
@@ -4370,6 +4561,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, ""),
             &engineer,
         );
@@ -4381,6 +4573,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("FILTER"),
+            &Priority::Low,
             &String::from_str(&env, ""),
             &engineer,
         );
@@ -4392,6 +4585,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, ""),
             &engineer,
         );
@@ -4402,6 +4596,7 @@ mod tests {
         let result = client.try_submit_maintenance(
             &asset_id,
             &symbol_short!("UNKNOWN"),
+            &Priority::Low,
             &String::from_str(&env, ""),
             &engineer,
         );
@@ -4426,6 +4621,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Major overhaul"),
             &engineer,
         );
@@ -4460,6 +4656,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Major overhaul"),
             &engineer,
         );
@@ -4500,6 +4697,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "first service"),
             &engineer,
         );
@@ -4510,6 +4708,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("FILTER"),
+            &Priority::Low,
             &String::from_str(&env, "second service"),
             &engineer,
         );
@@ -4574,6 +4773,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "maintenance"),
                 &engineer,
             );
@@ -4597,6 +4797,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "maintenance"),
                 &engineer,
             );
@@ -4891,14 +5092,17 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "First"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("INSPECT"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Second"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("ENGINE"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Third"),
         });
 
@@ -4924,6 +5128,7 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "ttl test"),
         });
         client.batch_submit_maintenance(&asset_id, &records, &engineer);
@@ -4960,6 +5165,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "oil change"),
                 &engineer,
             );
@@ -5007,6 +5213,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "oil change"),
                 &engineer,
             );
@@ -5050,6 +5257,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "oil change"),
                 &engineer,
             );
@@ -5081,6 +5289,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Maintenance"),
             &engineer,
         );
@@ -5128,6 +5337,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Maintenance"),
             &engineer,
         );
@@ -5162,10 +5372,12 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Oil change"),
         });
         records.push_back(BatchRecord {
             task_type: symbol_short!("INSPECT"),
+            priority: Priority::Low,
             notes: String::from_str(&env, "Inspection"),
         });
 
@@ -5203,6 +5415,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "first"),
             &engineer,
         );
@@ -5229,6 +5442,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "first"),
             &engineer,
         );
@@ -5237,6 +5451,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "second"),
             &engineer,
         );
@@ -5260,6 +5475,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, "Maintenance"),
             &engineer,
         );
@@ -5303,6 +5519,7 @@ mod tests {
             client.try_submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, ""),
                 &engineer
             ),
@@ -5315,6 +5532,7 @@ mod tests {
         let mut records = Vec::new(&env);
         records.push_back(BatchRecord {
             task_type: symbol_short!("OIL_CHG"),
+            priority: Priority::Low,
             notes: String::from_str(&env, ""),
         });
         assert_eq!(
@@ -5413,6 +5631,7 @@ mod tests {
             client.try_submit_maintenance(
                 &asset_id,
                 &symbol_short!("OIL_CHG"),
+                &Priority::Low,
                 &String::from_str(&env, "should be blocked"),
                 &engineer,
             ),
@@ -5435,6 +5654,7 @@ mod tests {
         client.submit_maintenance(
             &asset1,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Session 1"),
             &engineer,
         );
@@ -5443,6 +5663,7 @@ mod tests {
         client.submit_maintenance(
             &asset2,
             &symbol_short!("INSPECT"),
+            &Priority::Low,
             &String::from_str(&env, "Session 2"),
             &engineer,
         );
@@ -5467,6 +5688,7 @@ mod tests {
             client.submit_maintenance(
                 &asset_id,
                 &symbol_short!("FILTER"),
+                &Priority::Low,
                 &String::from_str(&env, "Filter replacement"),
                 &engineer,
             );
@@ -5478,6 +5700,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("FILTER"),
+            &Priority::Low,
             &String::from_str(&env, "Filter replacement"),
             &engineer,
         );
@@ -5523,6 +5746,7 @@ mod tests {
             lifecycle.submit_maintenance(
                 &asset_id,
                 &symbol_short!("OVERHAUL"),
+                &Priority::Low,
                 &String::from_str(&env, "Full overhaul"),
                 &engineer,
             );
@@ -5597,12 +5821,14 @@ mod tests {
         lifecycle.submit_maintenance(
             &asset_id,
             &symbol_short!("INSPECT"),
+            &Priority::Low,
             &String::from_str(&env, "Pre-transfer inspection"),
             &engineer,
         );
         lifecycle.submit_maintenance(
             &asset_id,
             &symbol_short!("OIL_CHG"),
+            &Priority::Low,
             &String::from_str(&env, "Oil change"),
             &engineer,
         );
@@ -5658,6 +5884,7 @@ mod tests {
         lifecycle.submit_maintenance(
             &asset_id,
             &symbol_short!("INSPECT"),
+            &Priority::Low,
             &String::from_str(&env, "Pre-deregister check"),
             &engineer,
         );
@@ -5793,6 +6020,7 @@ mod tests {
         client.submit_maintenance(
             &asset_id,
             &symbol_short!("ENGINE"),
+            &Priority::Low,
             &String::from_str(&env, ""),
             &engineer,
         );
@@ -5835,6 +6063,7 @@ mod tests {
         lifecycle.submit_maintenance(
             &asset_id,
             &symbol_short!("INSPECT"),
+            &Priority::Low,
             &String::from_str(&env, "Routine check"),
             &engineer,
         );

--- a/docs/engineer-training.md
+++ b/docs/engineer-training.md
@@ -1,0 +1,143 @@
+# Engineer Training Records
+
+This document describes the training record tracking system in Mainstay's engineer registry. Training records provide verifiable proof of continuing education and certification renewals for credentialed engineers.
+
+## Overview
+
+The training system extends the engineer credentialing framework to include a complete history of training completions. Each training event is recorded on-chain by the engineer's original credential issuer, creating an immutable audit trail that regulators, auditors, and asset owners can verify.
+
+## Motivation
+
+- **Audit Compliance**: Auditors can verify engineers have completed required continuing education
+- **Renewal Tracking**: Credential renewals can reference training history
+- **Reputation Building**: Engineers accumulate verifiable training records over time
+- **Regulatory Alignment**: Supports industries with mandatory training hour requirements
+
+## Data Structure
+
+### TrainingRecord
+
+```rust
+pub struct TrainingRecord {
+    pub training_type: Symbol,       // Type of training completed
+    pub completion_date: u64,        // Unix timestamp of completion
+    pub certificate_hash: BytesN<32>, // SHA-256 hash of training certificate
+    pub issuer: Address,             // Issuer who recorded the training
+}
+```
+
+### Storage
+
+Training records are stored per-engineer under the key `(TRAIN, engineer_address) -> Vec<TrainingRecord>`. Records are appended chronologically and never removed, providing a permanent audit trail.
+
+## Training Types
+
+The `training_type` field is a `Symbol` that identifies the category of training. Below are the recommended training types:
+
+| Symbol | Description |
+|--------|-------------|
+| `SAFETY` | Workplace safety and hazard prevention |
+| `TECHNICAL` | Equipment-specific technical training |
+| `CERT_RENEW` | Certification renewal examination |
+| `CONT_ED` | Continuing education credits |
+| `OEM_TRAIN` | Original equipment manufacturer training |
+| `COMPLIANCE` | Regulatory compliance training |
+| `SPECIALTY` | Specialized skill development |
+| `REFRESHER` | Periodic refresher course |
+
+### Custom Training Types
+
+Issuers can use any `Symbol` value for custom training types. It is recommended to use short, uppercase identifiers consistent with the above convention.
+
+## API Operations
+
+### Record Training (Issuer-Only)
+
+```rust
+record_training(
+    engineer: Address,
+    training_type: Symbol,
+    completion_date: u64,
+    certificate_hash: BytesN<32>,
+)
+```
+
+**Authorization**: Must be called by the engineer's original credential issuer. The issuer must still be in the trusted issuers list.
+
+**Panics**:
+- `EngineerNotFound` — no engineer record exists for the given address
+- `UntrustedIssuer` — caller is not the engineer's issuer or issuer has been removed
+
+**Events**: Emits `REC_TRAIN` event with topics `(engineer_address)` and data `(training_type, completion_date, certificate_hash)`.
+
+### Get Training History
+
+```rust
+get_training_history(engineer: Address) -> Vec<TrainingRecord>
+```
+
+Returns the complete chronological training history for an engineer. Returns an empty vector if no training records exist.
+
+## Integration Examples
+
+### Recording a Training Completion (Shell)
+
+```bash
+stellar contract invoke \
+  --id $ENGINEER_REGISTRY_ID \
+  --source $ISSUER_KEY \
+  --network testnet \
+  -- \
+  record_training \
+  --engineer "$ENGINEER_ADDRESS" \
+  --training_type "SAFETY" \
+  --completion_date "$(date +%s)" \
+  --certificate_hash "$CERT_HASH"
+```
+
+### Querying Training History (Shell)
+
+```bash
+stellar contract invoke \
+  --id $ENGINEER_REGISTRY_ID \
+  --network testnet \
+  -- \
+  get_training_history \
+  --engineer "$ENGINEER_ADDRESS"
+```
+
+## Best Practices
+
+### For Issuers
+- **Verify Completion**: Confirm training was actually completed before recording
+- **Store Certificates**: Keep the original certificate corresponding to each `certificate_hash` off-chain
+- **Timely Recording**: Record training promptly after completion
+- **Consistent Typing**: Use standardized training type symbols across your organization
+
+### For Engineers
+- **Track Your Records**: Query your training history regularly
+- **Verify Accuracy**: Ensure all training completions are properly recorded
+- **Plan Renewals**: Use training history to demonstrate continuing education for credential renewals
+
+### For Auditors
+- **Verify On-Chain**: All training records are immutable once written
+- **Cross-Reference**: Match `certificate_hash` against off-chain certificate documents
+- **Track Timelines**: Verify training was completed within required time windows
+
+## Security Considerations
+
+- **Issuer-Only**: Only the original credential issuer can record training, preventing fraudulent self-reporting
+- **Trusted Issuer Check**: Training is rejected if the issuer has been removed from the trusted list
+- **Immutable**: Training records are append-only and cannot be deleted or modified
+- **Auditable**: All records are publicly verifiable on-chain
+
+## TTL Strategy
+
+Training records use persistent storage with automatic TTL extension on every write:
+- **Extension Threshold**: 518,400 ledgers (~30 days)
+- **Extension Target**: 518,400 ledgers (~30 days)
+- **Trigger**: Extended on every `record_training` call
+
+---
+
+*For general credentialing documentation, see [credentialing.md](credentialing.md).*


### PR DESCRIPTION
## Summary

Closes #855
Closes #856
Closes #883
Closes #884

Add testnet-smoke job to CI workflow (manual trigger only)
Deploy contracts using scripts/deploy_testnet.sh
Call register_asset via Stellar CLI
Assert return value is valid asset ID
Store deployed contract IDs as CI artifacts

Add WASM size check step to CI workflow after build
Set threshold at 80% of Soroban maximum (conservative)
Print WASM size in CI output for tracking
Fail CI if threshold exceeded
Add size badge to README

Add DataKey::EngineerTraining(Address) to store Vec of training records
Implement record_training(env, engineer_address, training_type, completion_date, certificate_hash) — issuer-only
Implement get_training_history(env, engineer_address) -> Vec
Add tests for training record tracking
Document training types in docs/engineer-training.md

