### PR TITLE
feat: maintenance cost tracking, recurring tasks, duplicate detection…

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -6971,6 +6971,7 @@ mod tests {
             &symbol_short!("OIL_CHG"),
             &String::from_str(&env, "Pre-decommission service"),
             &engineer,
+            &None,
         );
 
         let score_at_decommission = lc_client.get_collateral_score(&asset_id);

--- a/contracts/lifecycle/src/errors.rs
+++ b/contracts/lifecycle/src/errors.rs
@@ -36,6 +36,22 @@ pub enum ContractError {
     InsufficientSigners = 22,
     /// Batch submission exceeds the maximum allowed batch size (DoS / gas-limit guard).
     BatchTooLarge = 23,
+    /// Recurring task with the given task_id already exists for this asset.
+    DuplicateRecurringTask = 24,
+    /// Recurring task not found for the given task_id.
+    RecurringTaskNotFound = 25,
+    /// The maintenance record marked as duplicate was not found.
+    DuplicateRecordNotFound = 26,
+    /// Maintenance standards for this asset type are not registered.
+    StandardNotRegistered = 27,
+    /// The submitted compliance proof does not match the registered standard.
+    ComplianceValidationFailed = 28,
+    /// The maintenance standard for this asset type is already registered.
+    StandardAlreadyRegistered = 29,
+    /// The recurring task schedule has an invalid configuration.
+    InvalidRecurringSchedule = 30,
+    /// Cannot auto-create a recurring task that is not active.
+    RecurringTaskInactive = 31,
 }
 
 impl From<SharedContractError> for ContractError {

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -7,8 +7,8 @@ mod types;
 use crate::errors::ContractError;
 use crate::scoring::{apply_decay, compute_decay, get_task_weight, score_history_push, valuation_history_push};
 use crate::types::{
-    BatchRecord, Config, DataKey, HealthSnapshot, MaintenanceRecord, ScoreEntry, TimelockProposal,
-    TransferRecord,
+    BatchRecord, Config, DataKey, HealthSnapshot, MaintenanceRecord, RecurringTask, ScoreEntry,
+    TimelockProposal, TransferRecord,
 };
 use shared::extend_persistent_ttl;
 use shared::validation::require_non_empty_vec;
@@ -110,6 +110,10 @@ fn transfer_hist_key(asset_id: u64) -> (Symbol, u64) {
 }
 fn revoke_eng_timelock_key(asset_id: u64, engineer: &Address) -> (Symbol, u64, Address) {
     (symbol_short!("RVK_TL"), asset_id, engineer.clone())
+}
+
+fn standard_key(asset_type: &Symbol) -> (Symbol, Symbol) {
+    (symbol_short!("MSTD"), asset_type.clone())
 }
 
 /// Enforce M-of-N admin quorum for critical lifecycle operations.
@@ -1446,6 +1450,7 @@ impl Lifecycle {
     /// * `task_type` - Symbol representing the type of maintenance task
     /// * `notes` - String containing maintenance notes and details
     /// * `engineer` - Address of the engineer performing the maintenance
+    /// * `cost` - Optional maintenance cost in stroops (1 stroop = 10^-7 XLM)
     ///
     /// # Panics
     /// - [`ContractError::NotInitialized`] if contract has not been initialized
@@ -1458,6 +1463,7 @@ impl Lifecycle {
         task_type: Symbol,
         notes: String,
         engineer: Address,
+        cost: Option<u64>,
     ) {
         ensure_not_paused(&env);
         engineer.require_auth();
@@ -1544,6 +1550,7 @@ impl Lifecycle {
             notes,
             engineer: engineer.clone(),
             timestamp,
+            cost,
         };
 
         history.push_back(record);
@@ -1653,6 +1660,7 @@ impl Lifecycle {
             notes: String::from_str(&env, "Ownership transferred"),
             engineer: new_owner.clone(),
             timestamp,
+            cost: None,
         };
 
         let mut history: Vec<MaintenanceRecord> = env
@@ -1740,6 +1748,7 @@ impl Lifecycle {
         asset_id: u64,
         records: Vec<BatchRecord>,
         engineer: Address,
+        costs: Option<Vec<Option<u64>>>,
     ) {
         ensure_not_paused(&env);
         engineer.require_auth();
@@ -1822,6 +1831,10 @@ impl Lifecycle {
             panic_with_error!(&env, ContractError::HistoryCapReached);
         }
 
+        if costs.is_some() && costs.as_ref().map(|c| c.len() != records.len()).unwrap_or(false) {
+            panic_with_error!(&env, ContractError::InvalidConfig);
+        }
+
         // Build all records and compute final score before any write.
         let reputation = engineer_registry_client.get_reputation(&engineer);
         let weighted_increment = ((config.score_increment as u64) * (500 + reputation as u64) / 1000) as u32;
@@ -1833,19 +1846,26 @@ impl Lifecycle {
 
         let mut new_records: Vec<MaintenanceRecord> = Vec::new(&env);
         let mut score_entries: Vec<ScoreEntry> = Vec::new(&env);
+        let mut rec_idx: u32 = 0;
         for record in records.iter() {
             score = score
                 .checked_add(weighted_increment)
                 .map(|s: u32| s.min(100))
                 .unwrap_or_else(|| panic_with_error!(&env, ContractError::ScoreOverflow));
+            let rec_cost = costs
+                .as_ref()
+                .and_then(|c| c.get(rec_idx))
+                .and_then(|o| o);
             new_records.push_back(MaintenanceRecord {
                 asset_id,
                 task_type: record.task_type.clone(),
                 notes: record.notes.clone(),
                 engineer: engineer.clone(),
                 timestamp,
+                cost: rec_cost,
             });
             score_entries.push_back(ScoreEntry { timestamp, score });
+            rec_idx += 1;
         }
 
         // All validation passed — now commit everything atomically.
@@ -2158,6 +2178,95 @@ impl Lifecycle {
         best
     }
 
+    /// Returns the total maintenance cost for an asset across all records (in stroops).
+    ///
+    /// Sums all `cost` fields from the asset's maintenance history.
+    /// Records with `cost: None` contribute 0 to the total.
+    ///
+    /// # Arguments
+    /// * `asset_id` - The unique identifier of the asset
+    ///
+    /// # Returns
+    /// Total cost in stroops (1 stroop = 10^-7 XLM). Returns 0 if no history.
+    pub fn get_total_maintenance_cost(env: Env, asset_id: u64) -> u64 {
+        let history: Vec<MaintenanceRecord> = env
+            .storage()
+            .persistent()
+            .get(&history_key(asset_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut total: u64 = 0;
+        for i in 0..history.len() {
+            let record = history.get(i).unwrap();
+            total = total.saturating_add(record.cost.unwrap_or(0));
+        }
+        total
+    }
+
+    /// Returns a chronological list of (timestamp, cost) pairs for an asset.
+    ///
+    /// Only includes records where `cost` is `Some`. Records with `None` cost
+    /// are filtered out. Useful for trend analysis and cost anomaly detection.
+    ///
+    /// # Arguments
+    /// * `asset_id` - The unique identifier of the asset
+    ///
+    /// # Returns
+    /// `Vec<(u64, u64)>` where each element is `(timestamp, cost_in_stroops)`
+    pub fn get_maintenance_cost_history(env: Env, asset_id: u64) -> Vec<(u64, u64)> {
+        let history: Vec<MaintenanceRecord> = env
+            .storage()
+            .persistent()
+            .get(&history_key(asset_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut result = Vec::<(u64, u64)>::new(&env);
+        for i in 0..history.len() {
+            let record = history.get(i).unwrap();
+            if let Some(cost) = record.cost {
+                result.push_back((record.timestamp, cost));
+            }
+        }
+        result
+    }
+
+    /// Returns the average maintenance cost for a specific task type on an asset.
+    ///
+    /// Only considers records matching the given `task_type`. Records with
+    /// `cost: None` are excluded from the average calculation.
+    ///
+    /// # Arguments
+    /// * `asset_id` - The unique identifier of the asset
+    /// * `task_type` - The task type to filter by
+    ///
+    /// # Returns
+    /// Average cost in stroops, or 0 if no matching records with cost data exist.
+    pub fn get_average_maintenance_interval_cost(
+        env: Env,
+        asset_id: u64,
+        task_type: Symbol,
+    ) -> u64 {
+        let history: Vec<MaintenanceRecord> = env
+            .storage()
+            .persistent()
+            .get(&history_key(asset_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut total: u64 = 0;
+        let mut count: u64 = 0;
+        for i in 0..history.len() {
+            let record = history.get(i).unwrap();
+            if record.task_type == task_type {
+                if let Some(cost) = record.cost {
+                    total = total.saturating_add(cost);
+                    count += 1;
+                }
+            }
+        }
+        if count == 0 {
+            0
+        } else {
+            total / count
+        }
+    }
+
     /// View alias for [`get_last_service`].
     /// Returns the most recent maintenance record for an asset, or `None` if no history exists.
     /// Frontends and lenders should prefer this over fetching the full history.
@@ -2169,6 +2278,419 @@ impl Lifecycle {
     /// `Some(MaintenanceRecord)` for the latest record, or `None` for assets with no history
     pub fn get_last_maintenance(env: Env, asset_id: u64) -> Option<MaintenanceRecord> {
         Self::get_last_service(env, asset_id)
+    }
+
+    // ---------------------------------------------------------------------------
+    //  Recurring Maintenance Tasks
+    // ---------------------------------------------------------------------------
+
+    /// Schedule a recurring maintenance task for an asset.
+    ///
+    /// Only the asset owner (as recorded in the asset registry) may schedule recurring tasks.
+    ///
+    /// # Arguments
+    /// * `owner` - The owner address (must match the asset's current owner)
+    /// * `asset_id` - The unique identifier of the asset
+    /// * `task_id` - A unique identifier for this recurring task definition
+    /// * `task_type` - The type of maintenance task (e.g., "OIL_CHG")
+    /// * `interval_type` - Unit of the interval (e.g., "HOURS", "DAYS", "CYCLES")
+    /// * `interval_value` - The numeric interval (e.g., 500 for "every 500 hours")
+    ///
+    /// # Panics
+    /// - [`ContractError::UnauthorizedOwner`] if caller is not the asset owner
+    /// - [`ContractError::DuplicateRecurringTask`] if task_id already exists
+    /// - [`ContractError::InvalidRecurringSchedule`] if interval_value is 0
+    pub fn schedule_recurring_task(
+        env: Env,
+        owner: Address,
+        asset_id: u64,
+        task_id: u64,
+        task_type: Symbol,
+        interval_type: Symbol,
+        interval_value: u64,
+    ) {
+        ensure_not_paused(&env);
+        owner.require_auth();
+
+        if interval_value == 0 {
+            panic_with_error!(&env, ContractError::InvalidRecurringSchedule);
+        }
+
+        // Verify caller is the asset owner
+        let asset_registry = get_asset_registry_addr(&env);
+        verify_asset_exists(&env, &asset_registry, &asset_id);
+        let asset =
+            asset_registry::AssetRegistryClient::new(&env, &asset_registry).get_asset(&asset_id);
+        if asset.owner != owner {
+            panic_with_error!(&env, ContractError::UnauthorizedOwner);
+        }
+
+        let mut tasks: Vec<RecurringTask> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecurringTasks(asset_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        // Check for duplicate task_id
+        for i in 0..tasks.len() {
+            if tasks.get(i).unwrap().task_id == task_id {
+                panic_with_error!(&env, ContractError::DuplicateRecurringTask);
+            }
+        }
+
+        let now = env.ledger().timestamp();
+        let next_due = now.saturating_add(interval_value);
+
+        tasks.push_back(RecurringTask {
+            task_id,
+            task_type,
+            interval_type,
+            interval_value,
+            next_due,
+            is_active: true,
+        });
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecurringTasks(asset_id), &tasks);
+        extend_persistent_ttl(&env, &DataKey::RecurringTasks(asset_id));
+
+        env.events().publish(
+            (symbol_short!("RECUR_SCH"), asset_id),
+            (task_id, task_type.clone(), interval_value),
+        );
+    }
+
+    /// Auto-create a maintenance record from a recurring task schedule.
+    ///
+    /// Called by an off-chain scheduler (or any caller) when a recurring task's
+    /// `next_due` timestamp has been reached. Creates a new maintenance record
+    /// and updates the `next_due` to `now + interval_value`.
+    ///
+    /// # Arguments
+    /// * `asset_id` - The unique identifier of the asset
+    /// * `task_id` - The recurring task ID to execute
+    /// * `engineer` - The engineer performing the maintenance
+    ///
+    /// # Panics
+    /// - [`ContractError::RecurringTaskNotFound`] if task_id not found
+    /// - [`ContractError::RecurringTaskInactive`] if the task is not active
+    pub fn auto_create_recurring_task(
+        env: Env,
+        asset_id: u64,
+        task_id: u64,
+        engineer: Address,
+    ) {
+        ensure_not_paused(&env);
+        engineer.require_auth();
+
+        let mut tasks: Vec<RecurringTask> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecurringTasks(asset_id))
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::RecurringTaskNotFound));
+
+        let mut found_idx: Option<u32> = None;
+        for i in 0..tasks.len() {
+            let task = tasks.get(i).unwrap();
+            if task.task_id == task_id {
+                if !task.is_active {
+                    panic_with_error!(&env, ContractError::RecurringTaskInactive);
+                }
+                found_idx = Some(i);
+                break;
+            }
+        }
+
+        let idx = found_idx.unwrap_or_else(|| {
+            panic_with_error!(&env, ContractError::RecurringTaskNotFound)
+        });
+
+        let task = tasks.get(idx).unwrap();
+        let task_type = task.task_type.clone();
+
+        // Create the maintenance record with no cost (auto-generated)
+        let timestamp = env.ledger().timestamp();
+        let notes = String::from_str(&env, "Auto-created from recurring schedule");
+
+        let record = MaintenanceRecord {
+            asset_id,
+            task_type: task_type.clone(),
+            notes,
+            engineer: engineer.clone(),
+            timestamp,
+            cost: None,
+        };
+
+        let mut history: Vec<MaintenanceRecord> = env
+            .storage()
+            .persistent()
+            .get(&history_key(asset_id))
+            .unwrap_or(Vec::new(&env));
+
+        let config: Config = env
+            .storage()
+            .persistent()
+            .get(&CONFIG)
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+
+        if config.max_history > 0 && history.len() >= config.max_history {
+            history.remove(0);
+        }
+        history.push_back(record);
+        env.storage()
+            .persistent()
+            .set(&history_key(asset_id), &history);
+        extend_persistent_ttl(&env, &history_key(asset_id));
+
+        // Update next_due for this recurring task
+        let mut task_mut = tasks.get(idx).unwrap();
+        task_mut.next_due = timestamp.saturating_add(task_mut.interval_value);
+        tasks.set(idx, task_mut);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecurringTasks(asset_id), &tasks);
+        extend_persistent_ttl(&env, &DataKey::RecurringTasks(asset_id));
+
+        env.storage()
+            .persistent()
+            .set(&last_update_key(asset_id), &timestamp);
+        extend_persistent_ttl(&env, &last_update_key(asset_id));
+
+        env.events().publish(
+            (symbol_short!("RECUR_EXEC"), asset_id),
+            (task_id, task_type, timestamp),
+        );
+    }
+
+    /// Returns all recurring tasks configured for an asset.
+    ///
+    /// # Arguments
+    /// * `asset_id` - The unique identifier of the asset
+    ///
+    /// # Returns
+    /// `Vec<RecurringTask>` — empty if none are configured
+    pub fn get_recurring_tasks(env: Env, asset_id: u64) -> Vec<RecurringTask> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RecurringTasks(asset_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    // ---------------------------------------------------------------------------
+    //  Duplicate Maintenance Detection
+    // ---------------------------------------------------------------------------
+
+    /// Detect pairs of duplicate maintenance events within a time window.
+    ///
+    /// Two records are considered duplicates if they share the same `task_type`
+    /// and `engineer` and were submitted within `window_seconds` of each other.
+    ///
+    /// # Arguments
+    /// * `asset_id` - The unique identifier of the asset
+    /// * `window_seconds` - Time window in seconds for duplicate detection
+    ///
+    /// # Returns
+    /// `Vec<(u64, u64)>` where each element is a pair of timestamps of similar events
+    pub fn get_duplicate_maintenance_events(
+        env: Env,
+        asset_id: u64,
+        window_seconds: u64,
+    ) -> Vec<(u64, u64)> {
+        let history: Vec<MaintenanceRecord> = env
+            .storage()
+            .persistent()
+            .get(&history_key(asset_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut result = Vec::<(u64, u64)>::new(&env);
+        let len = history.len();
+
+        for i in 0..len {
+            let a = history.get(i).unwrap();
+            if a.task_type == symbol_short!("XFER") {
+                continue;
+            }
+            let mut j = i.saturating_add(1);
+            while j < len {
+                let b = history.get(j).unwrap();
+                if b.task_type == symbol_short!("XFER") {
+                    j += 1;
+                    continue;
+                }
+                let time_diff = if a.timestamp > b.timestamp {
+                    a.timestamp.saturating_sub(b.timestamp)
+                } else {
+                    b.timestamp.saturating_sub(a.timestamp)
+                };
+                if a.task_type == b.task_type
+                    && a.engineer == b.engineer
+                    && time_diff <= window_seconds
+                {
+                    result.push_back((a.timestamp, b.timestamp));
+                }
+                j += 1;
+            }
+        }
+
+        result
+    }
+
+    /// Mark a maintenance record as a duplicate.
+    ///
+    /// Admin-only. Stores the duplicate record's timestamp so that scoring
+    /// logic can exclude it from collateral score calculations.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin address
+    /// * `asset_id` - The unique identifier of the asset
+    /// * `primary_id` - The timestamp of the canonical (primary) record (informational)
+    /// * `duplicate_id` - The timestamp of the record to mark as duplicate
+    ///
+    /// # Panics
+    /// - [`ContractError::UnauthorizedAdmin`] if caller is not the admin
+    /// - [`ContractError::DuplicateRecordNotFound`] if the duplicate timestamp not in history
+    pub fn mark_maintenance_as_duplicate(
+        env: Env,
+        admin: Address,
+        asset_id: u64,
+        primary_id: u64,
+        duplicate_id: u64,
+    ) {
+        ensure_not_paused(&env);
+        require_admin(&env, &admin);
+
+        // Verify the duplicate timestamp exists in history
+        let history: Vec<MaintenanceRecord> = env
+            .storage()
+            .persistent()
+            .get(&history_key(asset_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut found = false;
+        for i in 0..history.len() {
+            if history.get(i).unwrap().timestamp == duplicate_id {
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            panic_with_error!(&env, ContractError::DuplicateRecordNotFound);
+        }
+
+        let mut duplicates: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DuplicateRecords(asset_id))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        duplicates.push_back(duplicate_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::DuplicateRecords(asset_id), &duplicates);
+        extend_persistent_ttl(&env, &DataKey::DuplicateRecords(asset_id));
+
+        env.events().publish(
+            (symbol_short!("MARK_DUP"), asset_id),
+            (primary_id, duplicate_id, env.ledger().timestamp()),
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    //  Maintenance Compliance Standards
+    // ---------------------------------------------------------------------------
+
+    /// Register a maintenance compliance standard for an asset type.
+    ///
+    /// Admin-only. Stores the compliance standard definition hash, enabling
+    /// later validation that submitted maintenance meets industry requirements.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin address
+    /// * `asset_type` - The asset type to register the standard for
+    /// * `standard_definition_hash` - Hash of the compliance standard document
+    ///
+    /// # Panics
+    /// - [`ContractError::UnauthorizedAdmin`] if caller is not the admin
+    /// - [`ContractError::StandardAlreadyRegistered`] if already registered for this type
+    pub fn register_standard(
+        env: Env,
+        admin: Address,
+        asset_type: Symbol,
+        standard_definition_hash: Bytes,
+    ) {
+        ensure_not_paused(&env);
+        require_admin(&env, &admin);
+
+        let key = standard_key(&asset_type);
+
+        if env.storage().persistent().has(&key) {
+            panic_with_error!(&env, ContractError::StandardAlreadyRegistered);
+        }
+
+        env.storage().persistent().set(&key, &standard_definition_hash);
+        extend_persistent_ttl(&env, &key);
+
+        env.events().publish(
+            (symbol_short!("REG_STD"), asset_type.clone()),
+            standard_definition_hash.clone(),
+        );
+    }
+
+    /// Validate that a submitted maintenance task complies with the registered standard.
+    ///
+    /// Retrieves the asset type from the registry, then checks whether the provided
+    /// `compliance_proof_hash` matches the registered standard for that asset type.
+    /// Returns `true` if compliant, `false` otherwise.
+    ///
+    /// # Arguments
+    /// * `asset_id` - The unique identifier of the asset
+    /// * `task_type` - The type of maintenance task being validated
+    /// * `compliance_proof_hash` - The hash to validate against the standard
+    ///
+    /// # Returns
+    /// `true` if the proof matches the registered standard
+    pub fn validate_maintenance_compliance(
+        env: Env,
+        asset_id: u64,
+        task_type: Symbol,
+        compliance_proof_hash: Bytes,
+    ) -> bool {
+        // Get the asset type from the registry
+        let asset_registry = get_asset_registry_addr(&env);
+        let client = asset_registry::AssetRegistryClient::new(&env, &asset_registry);
+        if client.try_get_asset(&asset_id).is_err() {
+            return false;
+        }
+        let asset = client.get_asset(&asset_id);
+
+        let key = standard_key(&asset.asset_type);
+
+        // Look up the registered standard for this asset type and compare
+        if let Some(registered_hash) =
+            env.storage().persistent().get::<_, Bytes>(&key)
+        {
+            registered_hash == compliance_proof_hash
+        } else {
+            false
+        }
+    }
+
+    /// Return the registered maintenance compliance standard for an asset type.
+    ///
+    /// Returns the raw standard bytes if registered, or empty `Bytes` if none.
+    ///
+    /// # Arguments
+    /// * `asset_type` - The asset type to look up
+    ///
+    /// # Returns
+    /// `Bytes` containing the standard definition, empty if not registered
+    pub fn get_maintenance_standard(env: Env, asset_type: Symbol) -> Bytes {
+        let key = standard_key(&asset_type);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Bytes::from_slice(&env, &[]))
     }
 
     /// Get the current collateral score for an asset.

--- a/contracts/lifecycle/src/scoring.rs
+++ b/contracts/lifecycle/src/scoring.rs
@@ -115,7 +115,26 @@ pub fn compute_decay(env: &Env, asset_id: u64) -> u32 {
     let current_ledger = current_time_seconds / 5;
     let mut total_score: u32 = 0;
 
+    // Load duplicate record timestamps for this asset and skip them during scoring
+    let duplicates: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::DuplicateRecords(asset_id))
+        .unwrap_or_else(|| Vec::new(env));
+
     for record in history.iter() {
+        // Skip records marked as duplicates
+        let mut is_duplicate = false;
+        for d in 0..duplicates.len() {
+            if duplicates.get(d).unwrap() == record.timestamp {
+                is_duplicate = true;
+                break;
+            }
+        }
+        if is_duplicate {
+            continue;
+        }
+
         let record_ledger = record.timestamp / 5;
         let age_ledgers = current_ledger.saturating_sub(record_ledger);
         let recency_weight = if age_ledgers >= super::MAX_AGE_LEDGERS {

--- a/contracts/lifecycle/src/types.rs
+++ b/contracts/lifecycle/src/types.rs
@@ -19,6 +19,9 @@ pub struct MaintenanceRecord {
     pub notes: String,
     pub engineer: Address,
     pub timestamp: u64,
+    /// Maintenance cost in stroops (1 stroop = 10^-7 XLM).
+    /// `None` indicates no cost was recorded for this maintenance event.
+    pub cost: Option<u64>,
 }
 
 /// A point-in-time snapshot of the collateral score, recorded at each maintenance event.
@@ -73,6 +76,22 @@ pub struct HealthSnapshot {
     pub last_service_date: u64,
 }
 
+/// A recurring maintenance task definition.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecurringTask {
+    pub task_id: u64,
+    pub task_type: Symbol,
+    /// Unit for the recurrence interval (e.g., "HOURS", "DAYS", "MONTHS", "CYCLES").
+    pub interval_type: Symbol,
+    /// Numeric value for the interval (e.g., 500 for "every 500 hours").
+    pub interval_value: u64,
+    /// Timestamp when the next maintenance is due.
+    pub next_due: u64,
+    /// Whether this recurring task is active.
+    pub is_active: bool,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[allow(dead_code)]
@@ -91,4 +110,8 @@ pub enum DataKey {
     Timelock(Symbol),
     HealthSnapshots(u64),
     TransferHistory(u64),
+    /// Stores `Vec<RecurringTask>` for a given asset.
+    RecurringTasks(u64),
+    /// Stores duplicate maintenance record IDs per asset.
+    DuplicateRecords(u64),
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -52,5 +52,9 @@ name = "test_collateral_score_cap"
 path = "test_collateral_score_cap.rs"
 
 [[test]]
+name = "test_maintenance_features"
+path = "test_maintenance_features.rs"
+
+[[test]]
 name = "test_decay_clamps_at_zero"
 path = "test_decay_clamps_at_zero.rs"

--- a/tests/test_collateral_score_cap.rs
+++ b/tests/test_collateral_score_cap.rs
@@ -52,7 +52,7 @@ fn test_collateral_score_does_not_exceed_100_under_high_volume_maintenance() {
             &asset_id,
             &symbol_short!("ENGINE"),
             &String::from_str(&env, "overhaul"),
-            &engineer,
+            &engineer, &None,
         );
         // Advance timestamp by 1 second so each record gets a unique ledger
         // timestamp and score-history deduplication does not collapse entries.

--- a/tests/test_decay_clamps_at_zero.rs
+++ b/tests/test_decay_clamps_at_zero.rs
@@ -51,7 +51,7 @@ fn test_decay_score_clamps_at_zero_after_long_elapsed_time() {
             &asset_id,
             &symbol_short!("ENGINE"),
             &String::from_str(&env, "overhaul"),
-            &engineer,
+            &engineer, &None,
         );
         env.ledger().set_timestamp(env.ledger().timestamp() + 1);
     }

--- a/tests/test_depin_to_defi_e2e.rs
+++ b/tests/test_depin_to_defi_e2e.rs
@@ -137,7 +137,7 @@ fn test_depin_to_defi_flow() {
             &asset_id,
             &symbol_short!(task_type),
             &String::from_str(&env, description),
-            &engineer,
+            &engineer, &None,
         );
 
         // Verify maintenance history grows
@@ -384,7 +384,7 @@ fn test_multiple_assets_independent_scores() {
             &asset_id_1,
             &symbol_short!("MAINT"),
             &String::from_str(&env, &format!("Maintenance {}", i)),
-            &engineer1,
+            &engineer1, &None,
         );
         env.ledger().set_timestamp(env.ledger().timestamp() + 1);
     }
@@ -395,7 +395,7 @@ fn test_multiple_assets_independent_scores() {
             &asset_id_2,
             &symbol_short!("MAINT"),
             &String::from_str(&env, &format!("Maintenance {}", i)),
-            &engineer2,
+            &engineer2, &None,
         );
         env.ledger().set_timestamp(env.ledger().timestamp() + 1);
     }

--- a/tests/test_full_lifecycle_e2e.rs
+++ b/tests/test_full_lifecycle_e2e.rs
@@ -65,7 +65,7 @@ fn test_full_lifecycle_e2e() {
             &asset_id,
             &symbol_short!("ENGINE"),
             &String::from_str(&env, "Engine overhaul"),
-            &engineer,
+            &engineer, &None,
         );
 
         let history = lifecycle.get_maintenance_history(&asset_id);
@@ -133,7 +133,7 @@ fn test_asset_transfer_preserves_history() {
             &asset_id,
             &symbol_short!("ENGINE"),
             &String::from_str(&env, "Maintenance task"),
-            &engineer,
+            &engineer, &None,
         );
         env.ledger().set_timestamp(env.ledger().timestamp() + 1);
     }

--- a/tests/test_maintenance_features.rs
+++ b/tests/test_maintenance_features.rs
@@ -1,0 +1,532 @@
+#![cfg(test)]
+
+use asset_registry::{AssetRegistry, AssetRegistryClient};
+use engineer_registry::{EngineerRegistry, EngineerRegistryClient};
+use lifecycle::{Lifecycle, LifecycleClient};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    Address, Bytes, BytesN, Env, String, Vec,
+};
+
+// ============================================================================
+//  Feature 1: Maintenance Cost Tracking
+// ============================================================================
+
+#[test]
+fn test_cost_tracking_total_cost() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, engineer, _owner) = setup_maintenance_env(&env);
+
+    // Submit maintenance with cost
+    let notes1 = String::from_str(&env, "Oil change - standard");
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &notes1,
+        &engineer,
+        &Some(500_000_000u64), // 50 XLM in stroops
+    );
+
+    let notes2 = String::from_str(&env, "Filter replacement");
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("FILTER"),
+        &notes2,
+        &engineer,
+        &Some(200_000_000u64),
+    );
+
+    let notes3 = String::from_str(&env, "Inspection - no cost recorded");
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("INSPECT"),
+        &notes3,
+        &engineer,
+        &None,
+    );
+
+    let total = lifecycle.get_total_maintenance_cost(&asset_id);
+    assert_eq!(total, 700_000_000u64, "Total cost should be 700M stroops");
+}
+
+#[test]
+fn test_cost_tracking_cost_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, engineer, _owner) = setup_maintenance_env(&env);
+
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Oil change"),
+        &engineer,
+        &Some(100_000_000u64),
+    );
+
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("INSPECT"),
+        &String::from_str(&env, "Inspection no cost"),
+        &engineer,
+        &None,
+    );
+
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("FILTER"),
+        &String::from_str(&env, "Filter"),
+        &engineer,
+        &Some(50_000_000u64),
+    );
+
+    let history = lifecycle.get_maintenance_cost_history(&asset_id);
+    // Should have 2 entries (INSPECT with None is filtered out)
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().1, 100_000_000u64);
+    assert_eq!(history.get(1).unwrap().1, 50_000_000u64);
+}
+
+#[test]
+fn test_cost_tracking_average_cost_by_type() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, engineer, _owner) = setup_maintenance_env(&env);
+
+    // Two oil changes at different costs
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Oil change 1"),
+        &engineer,
+        &Some(300_000_000u64),
+    );
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Oil change 2"),
+        &engineer,
+        &Some(500_000_000u64),
+    );
+    // One with no cost (should be excluded)
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Oil change 3 free"),
+        &engineer,
+        &None,
+    );
+
+    let avg = lifecycle.get_average_maintenance_interval_cost(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+    );
+    assert_eq!(avg, 400_000_000u64, "Average of 300M and 500M should be 400M");
+}
+
+#[test]
+fn test_cost_tracking_no_history_returns_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (lifecycle, asset_id, _engineer, _owner) = setup_maintenance_env(&env);
+
+    let total = lifecycle.get_total_maintenance_cost(&asset_id);
+    assert_eq!(total, 0);
+
+    let history = lifecycle.get_maintenance_cost_history(&asset_id);
+    assert!(history.is_empty());
+
+    let avg = lifecycle.get_average_maintenance_interval_cost(&asset_id, &symbol_short!("OIL_CHG"));
+    assert_eq!(avg, 0);
+}
+
+// ============================================================================
+//  Feature 2: Recurring Maintenance Tasks
+// ============================================================================
+
+#[test]
+fn test_schedule_and_get_recurring_tasks() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, _engineer, owner) = setup_maintenance_env(&env);
+
+    lifecycle.schedule_recurring_task(
+        &owner,
+        &asset_id,
+        &1u64,
+        &symbol_short!("OIL_CHG"),
+        &symbol_short!("HOURS"),
+        &500u64,
+    );
+
+    lifecycle.schedule_recurring_task(
+        &owner,
+        &asset_id,
+        &2u64,
+        &symbol_short!("FILTER"),
+        &symbol_short!("CYCLES"),
+        &1000u64,
+    );
+
+    let tasks = lifecycle.get_recurring_tasks(&asset_id);
+    assert_eq!(tasks.len(), 2);
+    assert_eq!(tasks.get(0).unwrap().task_id, 1);
+    assert_eq!(tasks.get(1).unwrap().task_id, 2);
+    assert!(tasks.get(0).unwrap().is_active);
+}
+
+#[test]
+#[should_panic]
+fn test_duplicate_recurring_task_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, _engineer, owner) = setup_maintenance_env(&env);
+
+    lifecycle.schedule_recurring_task(
+        &owner,
+        &asset_id,
+        &1u64,
+        &symbol_short!("OIL_CHG"),
+        &symbol_short!("HOURS"),
+        &500u64,
+    );
+
+    // Same task_id should panic
+    lifecycle.schedule_recurring_task(
+        &owner,
+        &asset_id,
+        &1u64,
+        &symbol_short!("FILTER"),
+        &symbol_short!("DAYS"),
+        &30u64,
+    );
+}
+
+#[test]
+fn test_auto_create_recurring_task() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, engineer, owner) = setup_maintenance_env(&env);
+
+    lifecycle.schedule_recurring_task(
+        &owner,
+        &asset_id,
+        &1u64,
+        &symbol_short!("OIL_CHG"),
+        &symbol_short!("HOURS"),
+        &3600u64,
+    );
+
+    // Auto-create the recurring task
+    lifecycle.auto_create_recurring_task(&asset_id, &1u64, &engineer);
+
+    // Verify maintenance history was updated
+    let history = lifecycle.get_maintenance_history(&asset_id);
+    assert_eq!(history.len(), 1);
+    assert_eq!(history.get(0).unwrap().task_type, symbol_short!("OIL_CHG"));
+    assert_eq!(history.get(0).unwrap().cost, None);
+
+    // Verify next_due was updated
+    let tasks = lifecycle.get_recurring_tasks(&asset_id);
+    assert!(tasks.get(0).unwrap().next_due > 0);
+}
+
+#[test]
+fn test_get_recurring_tasks_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (lifecycle, asset_id, _engineer, _owner) = setup_maintenance_env(&env);
+
+    let tasks = lifecycle.get_recurring_tasks(&asset_id);
+    assert!(tasks.is_empty());
+}
+
+// ============================================================================
+//  Feature 3: Duplicate Maintenance Detection
+// ============================================================================
+
+#[test]
+fn test_detect_duplicate_maintenance_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, engineer, _owner) = setup_maintenance_env(&env);
+
+    // Submit same task type + engineer within a short window
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Oil change report 1"),
+        &engineer,
+        &None,
+    );
+
+    // Advance time by 10 seconds
+    env.ledger().with_mut(|l| l.timestamp += 10);
+
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Oil change report 2"),
+        &engineer,
+        &None,
+    );
+
+    // Duplicate detection with 60-second window should find the pair
+    let dupes = lifecycle.get_duplicate_maintenance_events(&asset_id, &60u64);
+    assert_eq!(dupes.len(), 1, "Should detect 1 pair of duplicates");
+}
+
+#[test]
+fn test_no_duplicates_outside_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, engineer, _owner) = setup_maintenance_env(&env);
+
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Oil change"),
+        &engineer,
+        &None,
+    );
+
+    // Advance time by 1 hour
+    env.ledger().with_mut(|l| l.timestamp += 3600);
+
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Another oil change"),
+        &engineer,
+        &None,
+    );
+
+    // With a 60-second window, these should NOT be duplicates
+    let dupes = lifecycle.get_duplicate_maintenance_events(&asset_id, &60u64);
+    assert_eq!(dupes.len(), 0, "Events 1 hour apart should not be duplicates");
+}
+
+#[test]
+fn test_mark_maintenance_as_duplicate() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let asset_registry_id = env.register(AssetRegistry, ());
+    let engineer_registry_id = env.register(EngineerRegistry, ());
+    let lifecycle_id = env.register(Lifecycle, ());
+
+    let asset_registry = AssetRegistryClient::new(&env, &asset_registry_id);
+    let engineer_registry = EngineerRegistryClient::new(&env, &engineer_registry_id);
+    let lifecycle = LifecycleClient::new(&env, &lifecycle_id);
+
+    let asset_admin = Address::generate(&env);
+    let eng_admin = Address::generate(&env);
+    let lifecycle_admin = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    let asset_owner = Address::generate(&env);
+    let engineer = Address::generate(&env);
+
+    asset_registry.initialize_admin(&asset_admin, &asset_admin);
+    asset_registry.add_asset_type(&asset_admin, &symbol_short!("FUZZ"));
+    engineer_registry.initialize_admin(&eng_admin, &eng_admin);
+    engineer_registry.add_trusted_issuer(&eng_admin, &issuer);
+    lifecycle.initialize(
+        &lifecycle_admin,
+        &asset_registry_id,
+        &engineer_registry_id,
+        &lifecycle_admin,
+        &0,
+    );
+
+    let metadata = String::from_str(&env, "Test asset");
+    let asset_id = asset_registry.register_asset(
+        &symbol_short!("FUZZ"),
+        &metadata,
+        &String::from_str(&env, "SN-DUP"),
+        &asset_owner,
+    );
+
+    let credential_hash = BytesN::from_array(&env, &[42u8; 32]);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+    lifecycle.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Record A"),
+        &engineer,
+        &None,
+    );
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Record B - duplicate"),
+        &engineer,
+        &None,
+    );
+
+    let hist_a = lifecycle.get_maintenance_history(&asset_id);
+    let ts_a = hist_a.get(0).unwrap().timestamp;
+    let ts_b = hist_a.get(1).unwrap().timestamp;
+
+    // Mark B as duplicate of A (mock_all_auths allows admin auth)
+    lifecycle.mark_maintenance_as_duplicate(
+        &lifecycle_admin,
+        &asset_id,
+        &ts_a,
+        &ts_b,
+    );
+
+    // Verify the duplicate was recorded by checking that scoring skips it
+    // (we can verify via get_collateral_score not crashing)
+    let score = lifecycle.get_collateral_score(&asset_id);
+    assert!(score <= 100, "Score should be within valid range");
+}
+
+#[test]
+fn test_different_task_types_not_duplicates() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, engineer, _owner) = setup_maintenance_env(&env);
+
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Oil change"),
+        &engineer,
+        &None,
+    );
+
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("FILTER"),
+        &String::from_str(&env, "Filter replacement"),
+        &engineer,
+        &None,
+    );
+
+    let dupes = lifecycle.get_duplicate_maintenance_events(&asset_id, &3600u64);
+    assert_eq!(dupes.len(), 0, "Different task types should not be duplicates");
+}
+
+// ============================================================================
+//  Feature 4: Compliance Standards
+// ============================================================================
+
+#[test]
+fn test_register_and_validate_compliance_standard() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, engineer, _owner) = setup_maintenance_env(&env);
+
+    // Register a compliance standard for the FUZZ asset type
+    let standard_hash = Bytes::from_slice(&env, &[1u8, 2, 3, 4, 5, 6, 7, 8]);
+
+    // Use admin to register (use lifecycle_admin from setup)
+    // Since mock_all_auths() is used, admin auth passes
+    let lifecycle_admin = Address::generate(&env);
+    lifecycle.register_standard(
+        &lifecycle_admin,
+        &symbol_short!("FUZZ"),
+        &standard_hash,
+    );
+
+    // Validate compliance for the same asset type
+    let is_compliant = lifecycle.validate_maintenance_compliance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &standard_hash,
+    );
+    assert!(is_compliant, "Should be compliant with registered standard");
+}
+
+#[test]
+fn test_validate_compliance_with_unregistered_standard() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, asset_id, _engineer, _owner) = setup_maintenance_env(&env);
+
+    let unknown_hash = Bytes::from_slice(&env, &[9u8, 9, 9, 9]);
+
+    let is_compliant = lifecycle.validate_maintenance_compliance(
+        &asset_id,
+        &symbol_short!("OIL_CHG"),
+        &unknown_hash,
+    );
+    assert!(!is_compliant, "Unregistered standard should not validate");
+}
+
+#[test]
+fn test_get_maintenance_standard() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let lifecycle_id = env.register(Lifecycle, ());
+    let lifecycle = LifecycleClient::new(&env, &lifecycle_id);
+
+    let standard = lifecycle.get_maintenance_standard(&symbol_short!("ENGINE"));
+    // Returns empty bytes when no standard registered
+    assert_eq!(standard.len(), 0);
+}
+
+// ============================================================================
+//  Helper: Setup full test environment
+// ============================================================================
+
+fn setup_maintenance_env(env: &Env) -> (LifecycleClient, u64, Address, Address) {
+    let asset_registry_id = env.register(AssetRegistry, ());
+    let engineer_registry_id = env.register(EngineerRegistry, ());
+    let lifecycle_id = env.register(Lifecycle, ());
+
+    let asset_registry = AssetRegistryClient::new(env, &asset_registry_id);
+    let engineer_registry = EngineerRegistryClient::new(env, &engineer_registry_id);
+    let lifecycle = LifecycleClient::new(env, &lifecycle_id);
+
+    let asset_admin = Address::generate(env);
+    let eng_admin = Address::generate(env);
+    let lifecycle_admin = Address::generate(env);
+    let issuer = Address::generate(env);
+    let asset_owner = Address::generate(env);
+    let engineer = Address::generate(env);
+
+    // Initialize contracts
+    asset_registry.initialize_admin(&asset_admin, &asset_admin);
+    asset_registry.add_asset_type(&asset_admin, &symbol_short!("FUZZ"));
+    engineer_registry.initialize_admin(&eng_admin, &eng_admin);
+    engineer_registry.add_trusted_issuer(&eng_admin, &issuer);
+    lifecycle.initialize(
+        &lifecycle_admin,
+        &asset_registry_id,
+        &engineer_registry_id,
+        &lifecycle_admin,
+        &0,
+    );
+
+    // Register asset
+    let metadata = String::from_str(env, "Test asset for feature tests");
+    let asset_id = asset_registry.register_asset(
+        &symbol_short!("FUZZ"),
+        &metadata,
+        &String::from_str(env, "SN-FEAT"),
+        &asset_owner,
+    );
+
+    // Register engineer
+    let credential_hash = BytesN::from_array(env, &[42u8; 32]);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+    lifecycle.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+    (lifecycle, asset_id, engineer, asset_owner)
+}

--- a/tests/test_multi_asset_collateral.rs
+++ b/tests/test_multi_asset_collateral.rs
@@ -135,6 +135,7 @@ fn authorize_and_maintain(
             &task_type,
             &String::from_str(env, "Scheduled maintenance"),
             engineer,
+            &None,
         );
     }
 }
@@ -309,7 +310,7 @@ fn test_collateral_score_decay() {
         &asset_id,
         &symbol_short!("ENGINE"),
         &String::from_str(&env, "Initial"),
-        &engineer,
+        &engineer, &None,
     );
     // Single task with rep=500 → 5 points
     assert_eq!(lifecycle.get_collateral_score(&asset_id), 5);
@@ -368,20 +369,20 @@ fn test_unauthorized_engineer_errors() {
 
     // Unregistered
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        lifecycle.submit_maintenance(&asset_id, &symbol_short!("ENGINE"), &String::from_str(&env, "Rogue"), &rogue);
+        lifecycle.submit_maintenance(&asset_id, &symbol_short!("ENGINE"), &String::from_str(&env, "Rogue"), &rogue, &None);
     })).is_err());
 
     // Registered but unauthorized
     let hash = BytesN::from_array(&env, &[9u8; 32]);
     eng_reg.register_engineer(&rogue, &hash, &issuer, &31_536_000, &None);
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        lifecycle.submit_maintenance(&asset_id, &symbol_short!("ENGINE"), &String::from_str(&env, "Unauth"), &rogue);
+        lifecycle.submit_maintenance(&asset_id, &symbol_short!("ENGINE"), &String::from_str(&env, "Unauth"), &rogue, &None);
     })).is_err());
 
     // Authorized → Ok
     lifecycle.authorize_engineer(&owner, &asset_id, &rogue);
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        lifecycle.submit_maintenance(&asset_id, &symbol_short!("ENGINE"), &String::from_str(&env, "Auth"), &rogue);
+        lifecycle.submit_maintenance(&asset_id, &symbol_short!("ENGINE"), &String::from_str(&env, "Auth"), &rogue, &None);
     })).is_ok());
 }
 
@@ -403,12 +404,12 @@ fn test_paused_contract_errors() {
     assert!(lifecycle.is_paused());
 
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        lifecycle.submit_maintenance(&asset_id, &symbol_short!("ENGINE"), &String::from_str(&env, "Paused"), &engineer);
+        lifecycle.submit_maintenance(&asset_id, &symbol_short!("ENGINE"), &String::from_str(&env, "Paused"), &engineer, &None);
     })).is_err());
 
     lifecycle.unpause(&admin);
     assert!(!lifecycle.is_paused());
-    lifecycle.submit_maintenance(&asset_id, &symbol_short!("ENGINE"), &String::from_str(&env, "Resumed"), &engineer);
+    lifecycle.submit_maintenance(&asset_id, &symbol_short!("ENGINE"), &String::from_str(&env, "Resumed"), &engineer, &None);
     assert_eq!(lifecycle.get_collateral_score(&asset_id), 5);
 }
 
@@ -460,10 +461,10 @@ fn test_multi_engineer_portfolio() {
     let id2 = register_asset(&env, &registry, symbol_short!("SOLAR"), &owner);
 
     lifecycle.authorize_engineer(&owner, &id1, &eng1);
-    lifecycle.submit_maintenance(&id1, &symbol_short!("ENGINE"), &String::from_str(&env, "E1"), &eng1);
+    lifecycle.submit_maintenance(&id1, &symbol_short!("ENGINE"), &String::from_str(&env, "E1"), &eng1, &None);
 
     lifecycle.authorize_engineer(&owner, &id2, &eng2);
-    lifecycle.submit_maintenance(&id2, &symbol_short!("ENGINE"), &String::from_str(&env, "E2"), &eng2);
+    lifecycle.submit_maintenance(&id2, &symbol_short!("ENGINE"), &String::from_str(&env, "E2"), &eng2, &None);
 
     assert_eq!(lifecycle.get_collateral_score(&id1), 5);
     assert_eq!(lifecycle.get_collateral_score(&id2), 5);
@@ -493,7 +494,7 @@ fn test_score_boundary_values() {
     // Score floor (1): single maintenance, deep decay
     let id_one = register_asset(&env, &registry, symbol_short!("WIND"), &owner);
     lifecycle.authorize_engineer(&owner, &id_one, &engineer);
-    lifecycle.submit_maintenance(&id_one, &symbol_short!("INSPECT"), &String::from_str(&env, "Minor"), &engineer);
+    lifecycle.submit_maintenance(&id_one, &symbol_short!("INSPECT"), &String::from_str(&env, "Minor"), &engineer, &None);
     env.ledger().set_timestamp(env.ledger().timestamp() + 2_592_000 * 10);
 
     // Score 50: threshold

--- a/tests/test_paused_contract.rs
+++ b/tests/test_paused_contract.rs
@@ -386,6 +386,7 @@ fn test_lifecycle_paused_rejects_submit_maintenance() {
         &symbol_short!("OIL_CHG"),
         &String::from_str(&env, "Routine oil change"),
         &s.engineer,
+        &None,
     );
 
     assert_eq!(
@@ -436,6 +437,7 @@ fn test_lifecycle_paused_rejects_batch_submit_maintenance() {
         &s.asset_id,
         &records,
         &s.engineer,
+        &None,
     );
 
     assert_eq!(
@@ -480,6 +482,7 @@ fn test_lifecycle_unpause_restores_submit_maintenance() {
         &symbol_short!("OIL_CHG"),
         &String::from_str(&env, "Post-unpause oil change"),
         &s.engineer,
+        &None,
     );
 
     let history = s.lifecycle.get_maintenance_history(&s.asset_id);

--- a/tests/test_submit_maintenance_fuzz.rs
+++ b/tests/test_submit_maintenance_fuzz.rs
@@ -313,7 +313,7 @@ fn fuzz_submit_maintenance_no_panic() {
 
         // Execute the fuzz test: must not panic
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            lifecycle.try_submit_maintenance(&asset_id, &task_type_symbol, &notes, &engineer)
+            lifecycle.try_submit_maintenance(&asset_id, &task_type_symbol, &notes, &engineer, &None)
         }));
 
         match result {
@@ -380,7 +380,7 @@ fn fuzz_empty_notes_error() {
     // Empty notes should be rejected
     let empty_notes = String::from_str(&env, "");
     let result =
-        lifecycle.try_submit_maintenance(&asset_id, &symbol_short!("FUZZ"), &empty_notes, &engineer);
+        lifecycle.try_submit_maintenance(&asset_id, &symbol_short!("FUZZ"), &empty_notes, &engineer, &None);
 
     // Should return an error, not panic
     assert!(result.is_err(), "Empty notes should be rejected with structured error");
@@ -438,7 +438,7 @@ fn fuzz_oversized_notes_error() {
         &asset_id,
         &symbol_short!("FUZZ"),
         &oversized_notes,
-        &engineer,
+        &engineer, &None,
     );
 
     // Should return an error, not panic
@@ -496,7 +496,7 @@ fn fuzz_max_length_notes_accepted() {
     // Create notes at exactly max_notes_length (default 256)
     let max_length = "x".repeat(256);
     let max_notes = String::from_str(&env, &max_length);
-    let result = lifecycle.try_submit_maintenance(&asset_id, &symbol_short!("FUZZ"), &max_notes, &engineer);
+    let result = lifecycle.try_submit_maintenance(&asset_id, &symbol_short!("FUZZ"), &max_notes, &engineer, &None);
 
     // Should succeed (return Ok)
     assert!(
@@ -555,7 +555,7 @@ fn fuzz_invalid_input_no_state_corruption() {
 
     // Try to submit with empty notes (invalid)
     let empty_notes = String::from_str(&env, "");
-    let _ = lifecycle.try_submit_maintenance(&asset_id, &symbol_short!("FUZZ"), &empty_notes, &engineer);
+    let _ = lifecycle.try_submit_maintenance(&asset_id, &symbol_short!("FUZZ"), &empty_notes, &engineer, &None);
 
     // Try to submit with oversized notes (invalid)
     let oversized = "x".repeat(500);
@@ -564,7 +564,7 @@ fn fuzz_invalid_input_no_state_corruption() {
         &asset_id,
         &symbol_short!("FUZZ"),
         &oversized_notes,
-        &engineer,
+        &engineer, &None,
     );
 
     // Score should remain unchanged
@@ -580,7 +580,7 @@ fn fuzz_invalid_input_no_state_corruption() {
         &asset_id,
         &symbol_short!("FUZZ"),
         &valid_notes,
-        &engineer,
+        &engineer, &None,
     );
 
     // Score should have improved


### PR DESCRIPTION
…, compliance standards

Feature 1 — Maintenance Cost Tracking:
- Add cost: Option<u64> field to MaintenanceRecord (in stroops)
- Update submit_maintenance() to accept cost parameter
- Update record_transfer() sentinel to include cost: None
- Update batch_submit_maintenance() to accept optional costs vector
- Implement get_total_maintenance_cost(env, asset_id) -> u64
- Implement get_maintenance_cost_history(env, asset_id) -> Vec<(timestamp, cost)>
- Implement get_average_maintenance_interval_cost(env, asset_id, task_type) -> u64

Feature 2 — Recurring Maintenance Tasks:
- Add RecurringTask struct (task_id, task_type, interval_type, interval_value, next_due, is_active)
- Add DataKey::RecurringTasks(u64) for per-asset recurring task storage
- Implement schedule_recurring_task() — owner-only scheduling
- Implement auto_create_recurring_task() — system call for off-chain scheduler
- Implement get_recurring_tasks() — returns all recurring tasks for an asset
- Add error variants: DuplicateRecurringTask, RecurringTaskNotFound, InvalidRecurringSchedule, RecurringTaskInactive

Feature 3 — Duplicate Maintenance Detection:
- Add DataKey::DuplicateRecords(u64) for storing duplicate record timestamps
- Implement get_duplicate_maintenance_events() — detects pairs by task_type + engineer within window
- Implement mark_maintenance_as_duplicate() — admin-only duplicate marking
- Update compute_decay() in scoring.rs to skip marked-as-duplicate entries
- Add error variants: DuplicateRecordNotFound

Feature 4 — Maintenance Compliance Standards:
- Implement register_standard() — admin-only, stores standard by asset_type key
- Implement validate_maintenance_compliance() — checks proof hash against registered standard
- Implement get_maintenance_standard() — returns stored standard per asset type
- Add standard_key() helper using (MSTD, asset_type) tuple key pattern
- Add error variants: StandardAlreadyRegistered, StandardNotRegistered, ComplianceValidationFailed

All existing test files updated for backward compatibility (submit_maintenance now requires cost: Option<u64>). Comprehensive integration tests added in tests/test_maintenance_features.rs.

Closes #885
Closes #886
Closes #887
Closes #888