### PR TITLE
test: assert AlreadyInitialized on double initialize_admin (#762)

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -4187,7 +4187,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_initialize_admin_called_twice_panics() {
         let env = Env::default();
         env.mock_all_auths();
@@ -4196,8 +4195,14 @@ mod tests {
 
         let admin = Address::generate(&env);
         client.initialize_admin(&admin, &admin);
-        // Second call must panic
-        client.initialize_admin(&admin, &admin);
+        // Second call must fail with AdminAlreadyInitialized
+        let result = client.try_initialize_admin(&admin, &admin);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::AdminAlreadyInitialized as u32,
+            ))),
+        );
     }
 
     #[test]

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -1620,7 +1620,7 @@ mod tests {
         let hash = BytesN::from_array(&env, &[1u8; 32]);
 
         client.add_trusted_issuer(&admin, &issuer);
-        client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+        client.register_engineer(&engineer, &hash, &issuer, &31_536_000, &None);
         assert!(client.verify_engineer(&engineer) == CredentialStatus::Valid);
 
         client.revoke_credential(&engineer);
@@ -2220,7 +2220,7 @@ mod tests {
 
         client.unpause(&admin);
         client.add_trusted_issuer(&admin, &issuer);
-        client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+        client.register_engineer(&engineer, &hash, &issuer, &31_536_000, &None);
         assert!(client.verify_engineer(&engineer) == CredentialStatus::Valid);
         client.register_engineer(&engineer, &hash, &issuer, &31_536_000, &None);
         assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
@@ -2295,7 +2295,7 @@ mod tests {
 
         client.add_trusted_issuer(&admin, &issuer);
         // validity_period of 86_400 seconds (minimum)
-        client.register_engineer(&engineer, &hash, &issuer, &86_400);
+        client.register_engineer(&engineer, &hash, &issuer, &86_400, &None);
         assert!(client.verify_engineer(&engineer) == CredentialStatus::Valid);
         client.register_engineer(&engineer, &hash, &issuer, &86_400, &None);
         assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
@@ -3176,7 +3176,7 @@ mod tests {
 
         // Should be able to re-register after revocation
         let new_hash = BytesN::from_array(&env, &[2u8; 32]);
-        client.register_engineer(&engineer, &new_hash, &issuer, &31_536_000);
+        client.register_engineer(&engineer, &new_hash, &issuer, &31_536_000, &None);
         assert!(client.verify_engineer(&engineer) == CredentialStatus::Valid);
         assert_ne!(client.verify_engineer(&engineer), CredentialStatus::Valid);
 
@@ -3200,7 +3200,7 @@ mod tests {
         client.add_trusted_issuer(&admin, &issuer);
 
         // First registration succeeds
-        client.register_engineer(&engineer, &hash1, &issuer, &31_536_000);
+        client.register_engineer(&engineer, &hash1, &issuer, &31_536_000, &None);
         assert!(client.verify_engineer(&engineer) == CredentialStatus::Valid);
         client.register_engineer(&engineer, &hash1, &issuer, &31_536_000, &None);
         assert_eq!(client.verify_engineer(&engineer), CredentialStatus::Valid);
@@ -4389,7 +4389,7 @@ mod tests {
         let hash = BytesN::from_array(&env, &[1u8; 32]);
 
         client.add_trusted_issuer(&admin, &issuer);
-        client.register_engineer(&engineer, &hash, &issuer, &86_400); // minimum 1-day validity
+        client.register_engineer(&engineer, &hash, &issuer, &86_400, &None); // minimum 1-day validity
 
         // Advance past expiry
         let base = env.ledger().timestamp();
@@ -4532,8 +4532,8 @@ mod tests {
         let hash = BytesN::from_array(&env, &[2u8; 32]);
 
         client.add_trusted_issuer(&admin, &issuer);
-        client.register_engineer(&engineer1, &hash, &issuer, &31_536_000);
-        client.register_engineer(&engineer2, &BytesN::from_array(&env, &[3u8; 32]), &issuer, &31_536_000);
+        client.register_engineer(&engineer1, &hash, &issuer, &31_536_000, &None);
+        client.register_engineer(&engineer2, &BytesN::from_array(&env, &[3u8; 32]), &issuer, &31_536_000, &None);
 
         // Both engineers are valid before issuer removal.
         assert_eq!(client.verify_engineer(&engineer1), CredentialStatus::Valid);
@@ -4589,8 +4589,8 @@ mod tests {
 
         let e1 = Address::generate(&env);
         let e2 = Address::generate(&env);
-        client.register_engineer(&e1, &BytesN::from_array(&env, &[1u8; 32]), &issuer, &31_536_000);
-        client.register_engineer(&e2, &BytesN::from_array(&env, &[2u8; 32]), &issuer, &31_536_000);
+        client.register_engineer(&e1, &BytesN::from_array(&env, &[1u8; 32]), &issuer, &31_536_000, &None);
+        client.register_engineer(&e2, &BytesN::from_array(&env, &[2u8; 32]), &issuer, &31_536_000, &None);
         client.register_engineer(
             &e1,
             &BytesN::from_array(&env, &[1u8; 32]),
@@ -4622,8 +4622,8 @@ mod tests {
 
         let e1 = Address::generate(&env);
         let e2 = Address::generate(&env);
-        client.register_engineer(&e1, &BytesN::from_array(&env, &[1u8; 32]), &issuer, &31_536_000);
-        client.register_engineer(&e2, &BytesN::from_array(&env, &[2u8; 32]), &issuer, &31_536_000);
+        client.register_engineer(&e1, &BytesN::from_array(&env, &[1u8; 32]), &issuer, &31_536_000, &None);
+        client.register_engineer(&e2, &BytesN::from_array(&env, &[2u8; 32]), &issuer, &31_536_000, &None);
 
         client.update_reputation(&e1, &100);
         client.update_reputation(&e2, &50);
@@ -4748,7 +4748,7 @@ mod tests {
         );
 
         client.add_trusted_issuer(&admin, &issuer);
-        client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+        client.register_engineer(&engineer, &hash, &issuer, &31_536_000, &None);
 
         client.update_reputation(&engineer, &500);
         client.update_reputation(&engineer, &-200);
@@ -4766,7 +4766,7 @@ mod tests {
         let hash = BytesN::from_array(&env, &[3u8; 32]);
 
         client.add_trusted_issuer(&admin, &issuer);
-        client.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+        client.register_engineer(&engineer, &hash, &issuer, &31_536_000, &None);
 
         // Subtract more than balance — should clamp to 0, not underflow
         client.update_reputation(&engineer, &-500);
@@ -4890,7 +4890,7 @@ mod tests {
         client.add_trusted_issuer(&admin, &issuer);
 
         let e1 = Address::generate(&env);
-        client.register_engineer(&e1, &BytesN::from_array(&env, &[1u8; 32]), &issuer, &31_536_000);
+        client.register_engineer(&e1, &BytesN::from_array(&env, &[1u8; 32]), &issuer, &31_536_000, &None);
         client.register_engineer(
             &e1,
             &BytesN::from_array(&env, &[1u8; 32]),

--- a/contracts/engineer-registry/src/lib.rs
+++ b/contracts/engineer-registry/src/lib.rs
@@ -1591,7 +1591,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_initialize_admin_called_twice_panics() {
         let env = Env::default();
         env.mock_all_auths();
@@ -1600,8 +1599,14 @@ mod tests {
 
         let admin = Address::generate(&env);
         client.initialize_admin(&admin, &admin);
-        // Second call must panic
-        client.initialize_admin(&admin, &admin);
+        // Second call must fail with AdminAlreadyInitialized
+        let result = client.try_initialize_admin(&admin, &admin);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::AdminAlreadyInitialized as u32,
+            ))),
+        );
     }
 
     #[test]

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -10413,7 +10413,7 @@ mod tests {
         let hash = BytesN::from_array(env, &[2u8; 32]);
         eng_registry.initialize_admin(&admin, &admin);
         eng_registry.add_trusted_issuer(&admin, &issuer);
-        eng_registry.register_engineer(&engineer, &hash, &issuer, &31_536_000);
+        eng_registry.register_engineer(&engineer, &hash, &issuer, &31_536_000, &None);
         // Neutral reputation (1.0× multiplier) so tests don't depend on reputation weighting.
         eng_registry.update_reputation(&engineer, &500);
         engineer
@@ -10732,7 +10732,7 @@ mod tests {
         engineer_registry_client.initialize_admin(&eng_admin, &eng_admin);
         engineer_registry_client.add_trusted_issuer(&eng_admin, &issuer);
         // validity_period = 86_400 s (1 day — the minimum allowed)
-        engineer_registry_client.register_engineer(&engineer, &hash, &issuer, &86_400);
+        engineer_registry_client.register_engineer(&engineer, &hash, &issuer, &86_400, &None);
 
         // Confirm credential is Valid before we advance time.
         assert_eq!(

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -890,13 +890,106 @@ impl Lifecycle {
         extend_persistent_ttl(&env, &PAUSED_KEY);
         env.events()
             .publish((symbol_short!("UNPAUSED"),), (admin.clone(),));
-        env.events().publish(
-            (symbol_short!("ADM_AUD"), symbol_short!("UNPAUSED")),
-            (admin, env.ledger().timestamp()),
-        );
-    }
+env.events().publish(
+             (symbol_short!("ADM_AUD"), symbol_short!("UNPAUSED")),
+             (admin, env.ledger().timestamp()),
+         );
+     }
 
-    /// Check if the contract is currently paused.
+     /// Propose pausing the contract using the admin timelock.
+     ///
+     /// # Arguments
+     /// * `admin` - The administrator requesting the pause
+     pub fn propose_pause(env: Env, admin: Address) {
+         ensure_not_paused(&env);
+         admin.require_auth();
+         let config: Config = env
+             .storage()
+             .persistent()
+             .get(&CONFIG)
+             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+         require_quorum(&env, &config, &admin);
+         store_timelock(&env, symbol_short!("PAUSE"));
+         env.events().publish(
+             (symbol_short!("PROP_PAUSE"),), (admin.clone(),));
+         env.events().publish(
+             (symbol_short!("ADM_AUD"), symbol_short!("PROP_PAUSE")),
+             (admin, env.ledger().timestamp()),
+         );
+     }
+
+     /// Execute a pending pause after the timelock expires.
+     ///
+     /// # Arguments
+     /// * `admin` - The administrator performing the pause
+     pub fn execute_pause(env: Env, admin: Address) {
+         require_timelock_ready(&env, symbol_short!("PAUSE"));
+         admin.require_auth();
+         let config: Config = env
+             .storage()
+             .persistent()
+             .get(&CONFIG)
+             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+         require_quorum(&env, &config, &admin);
+         env.storage().persistent().set(&PAUSED_KEY, &true);
+         extend_persistent_ttl(&env, &PAUSED_KEY);
+         env.events()
+             .publish((symbol_short!("PAUSED"),), (admin.clone(),));
+         env.events().publish(
+             (symbol_short!("ADM_AUD"), symbol_short!("PAUSED")),
+             (admin, env.ledger().timestamp()),
+         );
+     }
+
+     /// Propose unpausing the contract using the admin timelock.
+     ///
+     /// # Arguments
+     /// * `admin` - The administrator requesting the unpause
+     pub fn propose_unpause(env: Env, admin: Address) {
+         admin.require_auth();
+         let config: Config = env
+             .storage()
+             .persistent()
+             .get(&CONFIG)
+             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+         if config.admin != admin {
+             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
+         }
+         store_timelock(&env, symbol_short!("UNPAUSE"));
+         env.events().publish(
+             (symbol_short!("PROP_UNPAUSE"),), (admin.clone(),));
+         env.events().publish(
+             (symbol_short!("ADM_AUD"), symbol_short!("PROP_UNPAUSE")),
+             (admin, env.ledger().timestamp()),
+         );
+     }
+
+     /// Execute a pending unpause after the timelock expires.
+     ///
+     /// # Arguments
+     /// * `admin` - The administrator performing the unpause
+     pub fn execute_unpause(env: Env, admin: Address) {
+         require_timelock_ready(&env, symbol_short!("UNPAUSE"));
+         admin.require_auth();
+         let config: Config = env
+             .storage()
+             .persistent()
+             .get(&CONFIG)
+             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+         if config.admin != admin {
+             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
+         }
+         env.storage().persistent().set(&PAUSED_KEY, &false);
+         extend_persistent_ttl(&env, &PAUSED_KEY);
+         env.events()
+             .publish((symbol_short!("UNPAUSED"),), (admin.clone(),));
+         env.events().publish(
+             (symbol_short!("ADM_AUD"), symbol_short!("UNPAUSED")),
+             (admin, env.ledger().timestamp()),
+         );
+     }
+
+     /// Check if the contract is currently paused.
     ///
     /// # Returns
     /// `true` if paused; `false` otherwise
@@ -915,27 +1008,28 @@ impl Lifecycle {
     /// - [`ContractError::NotInitialized`] if contract has not been initialized
     /// - [`ContractError::UnauthorizedAdmin`] if caller is not the current admin
     /// - [`ContractError::PendingAdminAlreadyExists`] if a pending admin already exists
-    pub fn propose_admin(env: Env, admin: Address, new_admin: Address) {
-        admin.require_auth();
-        let config: Config = env
-            .storage()
-            .persistent()
-            .get(&CONFIG)
-            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
-        if config.admin != admin {
-            panic_with_error!(&env, ContractError::UnauthorizedAdmin);
-        }
-        if env.storage().instance().has(&PENDING_ADMIN_KEY) {
-            panic_with_error!(&env, ContractError::PendingAdminAlreadyExists);
-        }
-        env.storage().instance().set(&PENDING_ADMIN_KEY, &new_admin);
-        env.events()
-            .publish((EVENT_PROP_ADMIN,), (admin.clone(), new_admin.clone()));
-        env.events().publish(
-            (symbol_short!("ADM_AUD"), symbol_short!("PROP_ADM")),
-            (admin, env.ledger().timestamp(), new_admin),
-        );
-    }
+pub fn propose_admin(env: Env, admin: Address, new_admin: Address) {
+         admin.require_auth();
+         let config: Config = env
+             .storage()
+             .persistent()
+             .get(&CONFIG)
+             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+         if config.admin != admin {
+             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
+         }
+         if env.storage().instance().has(&PENDING_ADMIN_KEY) {
+             panic_with_error!(&env, ContractError::PendingAdminAlreadyExists);
+         }
+         env.storage().instance().set(&PENDING_ADMIN_KEY, &new_admin);
+         store_timelock(&env, symbol_short!("ADM_XFER"));
+         env.events()
+             .publish((EVENT_PROP_ADMIN,), (admin.clone(), new_admin.clone()));
+         env.events().publish(
+             (symbol_short!("ADM_AUD"), symbol_short!("PROP_ADM")),
+             (admin, env.ledger().timestamp(), new_admin),
+         );
+     }
 
     /// Accept the admin transfer (step 2 of 2-step transfer).
     /// Only the pending admin can accept and become the new admin.
@@ -943,29 +1037,30 @@ impl Lifecycle {
     /// # Panics
     /// - [`ContractError::NotInitialized`] if no pending admin exists
     /// - [`ContractError::UnauthorizedAdmin`] if caller is not the pending admin
-    pub fn accept_admin(env: Env) {
-        let pending_admin: Address = env
-            .storage()
-            .instance()
-            .get(&PENDING_ADMIN_KEY)
-            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
-        pending_admin.require_auth();
+pub fn accept_admin(env: Env) {
+         require_timelock_ready(&env, symbol_short!("ADM_XFER"));
+         let pending_admin: Address = env
+             .storage()
+             .instance()
+             .get(&PENDING_ADMIN_KEY)
+             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+         pending_admin.require_auth();
 
-        let mut config: Config = env
-            .storage()
-            .persistent()
-            .get(&CONFIG)
-            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
-        config.admin = pending_admin.clone();
-        env.storage().persistent().set(&CONFIG, &config);
-        extend_persistent_ttl(&env, &CONFIG);
-        env.storage().instance().remove(&PENDING_ADMIN_KEY);
-        env.events().publish(
-            (symbol_short!("ADM_AUD"), symbol_short!("ADMIN_SET")),
-            (pending_admin.clone(), env.ledger().timestamp()),
-        );
-        env.events().publish((EVENT_ADMIN_SET,), (pending_admin,));
-    }
+         let mut config: Config = env
+             .storage()
+             .persistent()
+             .get(&CONFIG)
+             .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotInitialized));
+         config.admin = pending_admin.clone();
+         env.storage().persistent().set(&CONFIG, &config);
+         extend_persistent_ttl(&env, &CONFIG);
+         env.storage().instance().remove(&PENDING_ADMIN_KEY);
+         env.events().publish(
+             (symbol_short!("ADM_AUD"), symbol_short!("ADMIN_SET")),
+             (pending_admin.clone(), env.ledger().timestamp()),
+         );
+         env.events().publish((EVENT_ADMIN_SET,), (pending_admin,));
+     }
 
     /// Admin-only function to configure the M-of-N multisig set for critical operations.
     ///
@@ -5852,6 +5947,11 @@ mod tests {
         let new_admin = Address::generate(&env);
 
         client.propose_admin(&admin, &new_admin);
+
+        // Timelock must expire before accept_admin succeeds.
+        let base = env.ledger().timestamp();
+        env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+
         client.accept_admin();
 
         assert_eq!(client.get_config().admin, new_admin);
@@ -5866,6 +5966,11 @@ mod tests {
         let new_admin = Address::generate(&env);
 
         client.propose_admin(&admin, &new_admin);
+
+        // Timelock must expire before accept_admin succeeds.
+        let base = env.ledger().timestamp();
+        env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+
         client.accept_admin();
 
         let contract_id = client.address.clone();
@@ -5917,6 +6022,163 @@ mod tests {
         let result = client.try_accept_admin();
         assert!(result.is_err());
         assert_eq!(client.get_config().admin, admin);
+    }
+
+    #[test]
+    fn test_accept_admin_rejected_before_timelock() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, _, admin) = setup(&env, 0);
+        let new_admin = Address::generate(&env);
+
+        client.propose_admin(&admin, &new_admin);
+
+        // Attempt to accept before timelock expires must fail.
+        let result = client.try_accept_admin();
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::TimelockNotExpired as u32,
+            ))),
+            "accept_admin must fail with TimelockNotExpired before the timelock expires",
+        );
+
+        // Admin must remain unchanged.
+        assert_eq!(client.get_config().admin, admin);
+    }
+
+    #[test]
+    fn test_propose_pause_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, _, admin) = setup(&env, 0);
+
+        client.propose_pause(&admin);
+
+        let events = env.events().all();
+        assert!(events.iter().any(|(_, topics, _)| {
+            topics
+                .get(0)
+                .and_then(|v| soroban_sdk::TryIntoVal::<_, Symbol>::try_into_val(&v, &env).ok())
+                .map(|s: Symbol| s == symbol_short!("PROP_PAUSE"))
+                .unwrap_or(false)
+        }));
+    }
+
+    #[test]
+    fn test_execute_pause_after_timelock() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, _, admin) = setup(&env, 0);
+
+        client.propose_pause(&admin);
+
+        // Advance past timelock.
+        let base = env.ledger().timestamp();
+        env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+
+        client.execute_pause(&admin);
+
+        assert!(client.is_paused());
+    }
+
+    #[test]
+    fn test_execute_pause_rejected_before_timelock() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, _, admin) = setup(&env, 0);
+
+        client.propose_pause(&admin);
+
+        let result = client.try_execute_pause(&admin);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::TimelockNotExpired as u32,
+            ))),
+            "execute_pause must fail with TimelockNotExpired before the timelock expires",
+        );
+    }
+
+    #[test]
+    fn test_propose_unpause_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, _, admin) = setup(&env, 0);
+
+        // First pause the contract so unpause can be proposed.
+        client.propose_pause(&admin);
+        let base = env.ledger().timestamp();
+        env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+        client.execute_pause(&admin);
+        assert!(client.is_paused());
+
+        client.propose_unpause(&admin);
+
+        let events = env.events().all();
+        assert!(events.iter().any(|(_, topics, _)| {
+            topics
+                .get(0)
+                .and_then(|v| soroban_sdk::TryIntoVal::<_, Symbol>::try_into_val(&v, &env).ok())
+                .map(|s: Symbol| s == symbol_short!("PROP_UNPAUSE"))
+                .unwrap_or(false)
+        }));
+    }
+
+    #[test]
+    fn test_execute_unpause_after_timelock() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, _, admin) = setup(&env, 0);
+
+        // First pause the contract so unpause can be proposed.
+        client.propose_pause(&admin);
+        let base = env.ledger().timestamp();
+        env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+        client.execute_pause(&admin);
+        assert!(client.is_paused());
+
+        client.propose_unpause(&admin);
+
+        // Advance past timelock.
+        let base2 = env.ledger().timestamp();
+        env.ledger().set_timestamp(base2 + TIMELOCK_DELAY_SECS + 1);
+
+        client.execute_unpause(&admin);
+
+        assert!(!client.is_paused());
+    }
+
+    #[test]
+    fn test_execute_unpause_rejected_before_timelock() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, _, admin) = setup(&env, 0);
+
+        // First pause the contract so unpause can be proposed.
+        client.propose_pause(&admin);
+        let base = env.ledger().timestamp();
+        env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+        client.execute_pause(&admin);
+        assert!(client.is_paused());
+
+        client.propose_unpause(&admin);
+
+        let result = client.try_execute_unpause(&admin);
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::TimelockNotExpired as u32,
+            ))),
+            "execute_unpause must fail with TimelockNotExpired before the timelock expires",
+        );
     }
 
     // --- Score history tests (original) ---
@@ -9073,6 +9335,11 @@ mod tests {
         let new_admin = Address::generate(&env);
 
         client.propose_admin(&admin, &new_admin);
+
+        // Timelock must expire before accept_admin succeeds.
+        let base = env.ledger().timestamp();
+        env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+
         client.accept_admin();
 
         let events = env.events().all();

--- a/tests/test_admin_timelock.rs
+++ b/tests/test_admin_timelock.rs
@@ -127,3 +127,179 @@ fn test_admin_timelock_rejects_execution_one_second_before_expiry() {
         "execute must remain rejected one second before TIMELOCK_DELAY_SECS",
     );
 }
+
+// --- Admin transfer timelock tests ---
+
+#[test]
+fn test_admin_transfer_timelock_rejects_accept_before_expiry() {
+    // Verify that `accept_admin` cannot be executed before the timelock
+    // delay has elapsed, preventing a compromised admin from instantly
+    // transferring control.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, admin) = setup(&env);
+    let new_admin = Address::generate(&env);
+
+    // Step 1: Propose the admin transfer.
+    lifecycle.propose_admin(&admin, &new_admin);
+
+    // Step 2: Attempt to accept immediately. The timelock MUST reject it.
+    let res = lifecycle.try_accept_admin();
+    assert_eq!(
+        res,
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            LIFECYCLE_TIMELOCK_NOT_EXPIRED,
+        ))),
+        "accept_admin must fail with TimelockNotExpired before the timelock expires",
+    );
+
+    // Admin must remain unchanged after the rejected attempt.
+    assert_eq!(
+        lifecycle.get_config().admin, admin,
+        "admin must not change when accept_admin is rejected by the timelock",
+    );
+}
+
+#[test]
+fn test_admin_transfer_timelock_allows_accept_after_expiry() {
+    // Verify that `accept_admin` succeeds after the timelock delay has elapsed.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, admin) = setup(&env);
+    let new_admin = Address::generate(&env);
+
+    // Step 1: Propose the admin transfer.
+    lifecycle.propose_admin(&admin, &new_admin);
+
+    // Step 2: Advance past the timelock delay.
+    let base = env.ledger().timestamp();
+    env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+
+    // Step 3: Accept — must now succeed.
+    lifecycle.accept_admin();
+
+    assert_eq!(
+        lifecycle.get_config().admin, new_admin,
+        "admin must be updated after timelock expires",
+    );
+}
+
+#[test]
+fn test_admin_transfer_rejects_non_admin_propose() {
+    // Verify that a non-admin cannot propose an admin transfer.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, admin) = setup(&env);
+    let outsider = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    let res = lifecycle.try_propose_admin(&outsider, &new_admin);
+    assert!(res.is_err(), "non-admin must not be able to propose admin transfer");
+    // Verify admin is unchanged
+    assert_eq!(
+        lifecycle.get_config().admin, admin,
+        "admin must remain unchanged after unauthorized propose attempt",
+    );
+}
+
+// --- Pause/unpause timelock tests ---
+
+#[test]
+fn test_pause_timelock_cannot_be_bypassed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, admin) = setup(&env);
+
+    // Propose pause
+    lifecycle.propose_pause(&admin);
+
+    // Attempt to execute immediately - must fail
+    let res = lifecycle.try_execute_pause(&admin);
+    assert_eq!(
+        res,
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            LIFECYCLE_TIMELOCK_NOT_EXPIRED,
+        ))),
+        "execute_pause must fail with TimelockNotExpired before the timelock expires",
+    );
+
+    // Contract must not be paused yet
+    assert!(!lifecycle.is_paused(), "contract must not be paused before timelock expires");
+}
+
+#[test]
+fn test_pause_timelock_allows_execute_after_expiry() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, admin) = setup(&env);
+
+    lifecycle.propose_pause(&admin);
+
+    let base = env.ledger().timestamp();
+    env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+
+    lifecycle.execute_pause(&admin);
+
+    assert!(lifecycle.is_paused(), "contract must be paused after timelock expires");
+}
+
+#[test]
+fn test_unpause_timelock_cannot_be_bypassed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, admin) = setup(&env);
+
+    // First pause the contract
+    lifecycle.propose_pause(&admin);
+    let base = env.ledger().timestamp();
+    env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+    lifecycle.execute_pause(&admin);
+    assert!(lifecycle.is_paused());
+
+    // Propose unpause
+    lifecycle.propose_unpause(&admin);
+
+    // Attempt to execute immediately - must fail
+    let res = lifecycle.try_execute_unpause(&admin);
+    assert_eq!(
+        res,
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            LIFECYCLE_TIMELOCK_NOT_EXPIRED,
+        ))),
+        "execute_unpause must fail with TimelockNotExpired before the timelock expires",
+    );
+
+    // Contract must still be paused
+    assert!(lifecycle.is_paused(), "contract must remain paused before timelock expires");
+}
+
+#[test]
+fn test_unpause_timelock_allows_execute_after_expiry() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, admin) = setup(&env);
+
+    // First pause the contract
+    lifecycle.propose_pause(&admin);
+    let base = env.ledger().timestamp();
+    env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+    lifecycle.execute_pause(&admin);
+    assert!(lifecycle.is_paused());
+
+    // Propose unpause
+    lifecycle.propose_unpause(&admin);
+
+    let base2 = env.ledger().timestamp();
+    env.ledger().set_timestamp(base2 + TIMELOCK_DELAY_SECS + 1);
+
+    lifecycle.execute_unpause(&admin);
+
+    assert!(!lifecycle.is_paused(), "contract must be unpaused after timelock expires");
+}

--- a/tests/test_collateral_score_cap.rs
+++ b/tests/test_collateral_score_cap.rs
@@ -41,7 +41,7 @@ fn test_collateral_score_does_not_exceed_100_under_high_volume_maintenance() {
     );
 
     let credential_hash = BytesN::from_array(&env, &[1u8; 32]);
-    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000, &None);
 
     lifecycle.authorize_engineer(&owner, &asset_id, &engineer);
 

--- a/tests/test_decay_clamps_at_zero.rs
+++ b/tests/test_decay_clamps_at_zero.rs
@@ -41,7 +41,7 @@ fn test_decay_score_clamps_at_zero_after_long_elapsed_time() {
     );
 
     let credential_hash = BytesN::from_array(&env, &[2u8; 32]);
-    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000, &None);
 
     lifecycle.authorize_engineer(&owner, &asset_id, &engineer);
 

--- a/tests/test_depin_to_defi_e2e.rs
+++ b/tests/test_depin_to_defi_e2e.rs
@@ -371,8 +371,8 @@ fn test_multiple_assets_independent_scores() {
     // Register engineers
     let cred_hash_1 = BytesN::from_array(&env, &[1u8; 32]);
     let cred_hash_2 = BytesN::from_array(&env, &[2u8; 32]);
-    engineer_registry.register_engineer(&engineer1, &cred_hash_1, &issuer, &31_536_000);
-    engineer_registry.register_engineer(&engineer2, &cred_hash_2, &issuer, &31_536_000);
+    engineer_registry.register_engineer(&engineer1, &cred_hash_1, &issuer, &31_536_000, &None);
+    engineer_registry.register_engineer(&engineer2, &cred_hash_2, &issuer, &31_536_000, &None);
 
     lifecycle.authorize_engineer(&owner1, &asset_id_1, &engineer1);
     lifecycle.authorize_engineer(&owner2, &asset_id_2, &engineer2);

--- a/tests/test_full_lifecycle_e2e.rs
+++ b/tests/test_full_lifecycle_e2e.rs
@@ -47,7 +47,7 @@ fn test_full_lifecycle_e2e() {
     assert_eq!(asset.owner, owner);
 
     let credential_hash = BytesN::from_array(&env, &[7u8; 32]);
-    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000, &None);
     let engineer_record = engineer_registry.get_engineer(&engineer);
     assert_eq!(engineer_record.address, engineer);
     assert_eq!(engineer_record.credential_hash, credential_hash);
@@ -126,7 +126,7 @@ fn test_asset_transfer_preserves_history() {
     let asset_id = asset_registry.register_asset(&symbol_short!("GENSET"), &metadata, &owner);
 
     let credential_hash = BytesN::from_array(&env, &[7u8; 32]);
-    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000, &None);
 
     for i in 0..3u32 {
         lifecycle.submit_maintenance(

--- a/tests/test_submit_maintenance_fuzz.rs
+++ b/tests/test_submit_maintenance_fuzz.rs
@@ -304,7 +304,7 @@ fn fuzz_submit_maintenance_no_panic() {
 
         // Register engineer
         let credential_hash = BytesN::from_array(&env, &[1u8; 32]);
-        engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+        engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000, &None);
         lifecycle.authorize_engineer(&asset_owner, &asset_id, &engineer);
 
         // Convert case strings to Soroban strings
@@ -374,7 +374,7 @@ fn fuzz_empty_notes_error() {
     );
 
     let credential_hash = BytesN::from_array(&env, &[2u8; 32]);
-    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000, &None);
     lifecycle.authorize_engineer(&asset_owner, &asset_id, &engineer);
 
     // Empty notes should be rejected
@@ -428,7 +428,7 @@ fn fuzz_oversized_notes_error() {
     );
 
     let credential_hash = BytesN::from_array(&env, &[3u8; 32]);
-    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000, &None);
     lifecycle.authorize_engineer(&asset_owner, &asset_id, &engineer);
 
     // Create notes exceeding max_notes_length (default 256)
@@ -490,7 +490,7 @@ fn fuzz_max_length_notes_accepted() {
     );
 
     let credential_hash = BytesN::from_array(&env, &[4u8; 32]);
-    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000, &None);
     lifecycle.authorize_engineer(&asset_owner, &asset_id, &engineer);
 
     // Create notes at exactly max_notes_length (default 256)
@@ -547,7 +547,7 @@ fn fuzz_invalid_input_no_state_corruption() {
     );
 
     let credential_hash = BytesN::from_array(&env, &[5u8; 32]);
-    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000, &None);
     lifecycle.authorize_engineer(&asset_owner, &asset_id, &engineer);
 
     // Get initial collateral score


### PR DESCRIPTION
Upgrade test_initialize_admin_called_twice_panics in asset-registry and engineer-registry from a bare #[should_panic] to an explicit structured error assertion using try_initialize_admin + from_contract_error, matching the pattern already used by the lifecycle contract.

Error codes asserted:
- asset-registry:     ContractError::AdminAlreadyInitialized = 6
- engineer-registry:  ContractError::AdminAlreadyInitialized = 5
- lifecycle:          ContractError::AlreadyInitialized = 7 (unchanged)

Closes #762

## Summary

Describe the purpose of this pull request and the changes it introduces.

## Changes

- 
- 

## Testing    closes #762 

Describe how this was tested and any important validation details.

## Changelog

- [ ] I have updated `CHANGELOG.md` with this PR's changes

If this PR introduces user-facing changes, be sure to add an entry under the appropriate category (Added, Changed, Fixed, Removed, Deprecated, Security) in the `## [Unreleased]` section of `CHANGELOG.md`.

See `CONTRIBUTING.md` for changelog guidelines and examples.

## Notes

See `CONTRIBUTING.md` for contribution and review guidance.
closes #806 