### PR TITLE
test(lifecycle): add collateral score decay interval tests — closes #…

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -62,3 +62,7 @@ path = "test_decay_clamps_at_zero.rs"
 [[test]]
 name = "test_decommissioned_asset_maintenance"
 path = "test_decommissioned_asset_maintenance.rs"
+
+[[test]]
+name = "test_collateral_score_decay_intervals"
+path = "test_collateral_score_decay_intervals.rs"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -66,3 +66,7 @@ path = "test_decommissioned_asset_maintenance.rs"
 [[test]]
 name = "test_collateral_score_decay_intervals"
 path = "test_collateral_score_decay_intervals.rs"
+
+[[test]]
+name = "test_suspended_engineer_rejected"
+path = "test_suspended_engineer_rejected.rs"

--- a/tests/test_collateral_score_decay_intervals.rs
+++ b/tests/test_collateral_score_decay_intervals.rs
@@ -1,0 +1,328 @@
+use asset_registry::{AssetRegistry, AssetRegistryClient};
+use engineer_registry::{EngineerRegistry, EngineerRegistryClient};
+use lifecycle::{Lifecycle, LifecycleClient};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    Address, BytesN, Env, String,
+};
+
+// ─── shared test helpers ───────────────────────────────────────────────────
+
+/// Fully boot all three contracts and return their clients together with an
+/// `admin` address that holds the lifecycle admin role.
+fn setup_contracts(
+    env: &Env,
+) -> (
+    AssetRegistryClient,
+    EngineerRegistryClient,
+    LifecycleClient,
+    Address,
+) {
+    let asset_registry_id = env.register(AssetRegistry, ());
+    let engineer_registry_id = env.register(EngineerRegistry, ());
+    let lifecycle_id = env.register(Lifecycle, ());
+
+    let asset_registry = AssetRegistryClient::new(env, &asset_registry_id);
+    let engineer_registry = EngineerRegistryClient::new(env, &engineer_registry_id);
+    let lifecycle = LifecycleClient::new(env, &lifecycle_id);
+
+    let admin = Address::generate(env);
+    let issuer = Address::generate(env);
+
+    asset_registry.initialize_admin(&admin, &admin);
+    asset_registry.add_asset_type(&admin, &symbol_short!("GENSET"));
+    engineer_registry.initialize_admin(&admin, &admin);
+    engineer_registry.add_trusted_issuer(&admin, &issuer);
+    // max_history = 0  →  use the contract default (200)
+    lifecycle.initialize(
+        &admin,
+        &asset_registry_id,
+        &engineer_registry_id,
+        &admin,
+        &0,
+    );
+
+    (asset_registry, engineer_registry, lifecycle, admin)
+}
+
+/// Register a fresh asset owned by a newly-generated address.
+/// Returns `(asset_id, owner)`.
+fn register_asset(
+    env: &Env,
+    asset_registry: &AssetRegistryClient,
+    label: &str,
+    serial: &str,
+) -> (u64, Address) {
+    let owner = Address::generate(env);
+    let asset_id = asset_registry.register_asset(
+        &symbol_short!("GENSET"),
+        &String::from_str(env, label),
+        &String::from_str(env, serial),
+        &owner,
+    );
+    (asset_id, owner)
+}
+
+/// Register a new engineer with a unique credential hash, add a trusted issuer
+/// to the registry (using `mock_all_auths`), authorize the engineer for
+/// `asset_id`, and return the engineer address.
+fn register_and_authorize_engineer(
+    env: &Env,
+    engineer_registry: &EngineerRegistryClient,
+    lifecycle: &LifecycleClient,
+    asset_id: u64,
+    owner: &Address,
+    hash_seed: u8,
+) -> Address {
+    let engineer = Address::generate(env);
+    let issuer = Address::generate(env);
+    let credential_hash = BytesN::from_array(env, &[hash_seed; 32]);
+    engineer_registry.register_engineer(&engineer, &credential_hash, &issuer, &31_536_000, &None);
+    lifecycle.authorize_engineer(owner, &asset_id, &engineer);
+    engineer
+}
+
+// ─── tests ─────────────────────────────────────────────────────────────────
+
+/// #1034 — Task 1
+/// Score decrements by `decay_rate` for every elapsed `decay_interval` across
+/// three consecutive intervals.
+///
+/// Setup:
+///   • Custom decay: rate = 3 pts, interval = 60 s
+///   • Submit enough maintenance to reach an initial stored score > 3 × 3 = 9
+///   • Advance ledger by 3 × 60 = 180 s
+///   • Call `decay_score` and assert score = initial − 9
+#[test]
+fn test_score_decrements_by_decay_rate_over_three_intervals() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (asset_registry, engineer_registry, lifecycle, admin) = setup_contracts(&env);
+    let (asset_id, owner) = register_asset(&env, &asset_registry, "Decay-3-interval asset", "SN-D3-001");
+    let engineer = register_and_authorize_engineer(
+        &env, &engineer_registry, &lifecycle, asset_id, &owner, 10,
+    );
+
+    // Submit 6 ENGINE records to build a stored score.
+    // With a brand-new engineer (reputation = 0) the effective increment per
+    // submission is floor(score_increment × 500 / 1000) = floor(5 × 0.5) = 2.
+    // 6 submissions → 12 pts stored — comfortably above the 9-pt decay target.
+    for _ in 0..6u32 {
+        lifecycle.submit_maintenance(
+            &asset_id,
+            &symbol_short!("ENGINE"),
+            &String::from_str(&env, "overhaul"),
+            &engineer,
+            &None,
+        );
+        // Advance 1 s between submissions so timestamps are unique.
+        env.ledger().set_timestamp(env.ledger().timestamp() + 1);
+    }
+
+    let initial_score = lifecycle.get_collateral_score(&asset_id);
+    assert!(
+        initial_score > 9,
+        "pre-condition: initial score {} must be > 9 to have room for 3-interval decay",
+        initial_score,
+    );
+
+    // Configure deterministic decay: 3 pts per 60-second interval.
+    let decay_rate: u32 = 3;
+    let decay_interval: u64 = 60;
+    lifecycle.update_decay_config(&admin, &decay_rate, &decay_interval);
+
+    // Advance exactly 3 full intervals (180 s).
+    env.ledger().set_timestamp(env.ledger().timestamp() + 3 * decay_interval);
+
+    let decayed_score = lifecycle.decay_score(&asset_id);
+    let expected = initial_score.saturating_sub(3 * decay_rate);
+
+    assert_eq!(
+        decayed_score,
+        expected,
+        "after 3 intervals (rate={}, interval={}s): expected score {} but got {}",
+        decay_rate,
+        decay_interval,
+        expected,
+        decayed_score,
+    );
+}
+
+/// #1034 — Task 2
+/// Score is clamped at `MIN_SCORE_WITH_HISTORY` (= 1) for an asset that *has*
+/// maintenance records, even after enough time has elapsed to drive the raw
+/// computed value below 1.
+///
+/// The floor ensures a maintained asset is always distinguishable from one
+/// with zero maintenance history.
+#[test]
+fn test_score_clamped_at_min_score_with_history_for_maintained_asset() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (asset_registry, engineer_registry, lifecycle, admin) = setup_contracts(&env);
+    let (asset_id, owner) = register_asset(&env, &asset_registry, "Floor-clamp asset", "SN-FL-001");
+    let engineer = register_and_authorize_engineer(
+        &env, &engineer_registry, &lifecycle, asset_id, &owner, 20,
+    );
+
+    // One ENGINE submission to ensure the asset has maintenance history.
+    lifecycle.submit_maintenance(
+        &asset_id,
+        &symbol_short!("ENGINE"),
+        &String::from_str(&env, "minor service"),
+        &engineer,
+        &None,
+    );
+
+    // Set aggressive decay: 50 pts per 10-second interval.
+    // Any existing stored score will be fully wiped within the first interval.
+    lifecycle.update_decay_config(&admin, &50, &10);
+
+    // Advance far beyond one interval so raw_score saturates to 0.
+    env.ledger().set_timestamp(env.ledger().timestamp() + 10_000);
+
+    // decay_score must return MIN_SCORE_WITH_HISTORY (1), not 0, because the
+    // asset has at least one maintenance record.
+    let floor_score = lifecycle.decay_score(&asset_id);
+    assert_eq!(
+        floor_score,
+        1,
+        "asset with maintenance history must be clamped at MIN_SCORE_WITH_HISTORY=1, got {}",
+        floor_score,
+    );
+
+    // A score of 1 is below the eligibility threshold (50) — not eligible.
+    assert!(
+        !lifecycle.is_collateral_eligible(&asset_id),
+        "asset with floor score of 1 must not be collateral-eligible",
+    );
+}
+
+/// #1034 — Task 3
+/// An asset with *no* maintenance records scores exactly 0 from `decay_score`.
+///
+/// The MIN_SCORE_WITH_HISTORY floor must NOT apply when the asset has no
+/// history — the result must be 0, not 1.
+#[test]
+fn test_score_is_zero_for_asset_with_no_maintenance_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (asset_registry, _engineer_registry, lifecycle, admin) = setup_contracts(&env);
+
+    // Register asset but deliberately submit no maintenance records.
+    let (asset_id, _owner) = register_asset(&env, &asset_registry, "No-history asset", "SN-NH-001");
+
+    // Use non-default decay params to confirm no code path special-cases them.
+    lifecycle.update_decay_config(&admin, &5, &60);
+
+    // Advance time; there is nothing to decay and no history floor applies.
+    env.ledger().set_timestamp(env.ledger().timestamp() + 600);
+
+    let score = lifecycle.decay_score(&asset_id);
+    assert_eq!(
+        score,
+        0,
+        "asset with no maintenance history must score 0, got {}",
+        score,
+    );
+
+    assert!(
+        !lifecycle.is_collateral_eligible(&asset_id),
+        "asset with no maintenance history must not be collateral-eligible",
+    );
+}
+
+/// #1034 — Task 4
+/// Score decrements by exactly `decay_rate` with each successive
+/// single-interval advance until the `MIN_SCORE_WITH_HISTORY` floor is hit.
+///
+/// This verifies the step-by-step precision of the decay logic: one
+/// `decay_score` call per interval must shed exactly `decay_rate` points
+/// every time until the floor clamps the result at 1.
+#[test]
+fn test_score_decrements_step_by_step_each_interval() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (asset_registry, engineer_registry, lifecycle, admin) = setup_contracts(&env);
+    let (asset_id, owner) = register_asset(&env, &asset_registry, "Step-decay asset", "SN-SD-001");
+    let engineer = register_and_authorize_engineer(
+        &env, &engineer_registry, &lifecycle, asset_id, &owner, 30,
+    );
+
+    // Build a score using 6 ENGINE submissions (≈ 12 pts stored at reputation 0).
+    for _ in 0..6u32 {
+        lifecycle.submit_maintenance(
+            &asset_id,
+            &symbol_short!("ENGINE"),
+            &String::from_str(&env, "overhaul"),
+            &engineer,
+            &None,
+        );
+        env.ledger().set_timestamp(env.ledger().timestamp() + 1);
+    }
+
+    let initial_score = lifecycle.get_collateral_score(&asset_id);
+
+    // Small, easy-to-reason-about decay config.
+    let decay_rate: u32 = 2;
+    let decay_interval: u64 = 30;
+    lifecycle.update_decay_config(&admin, &decay_rate, &decay_interval);
+
+    // Walk through intervals one at a time, verifying the score drops by
+    // exactly `decay_rate` each step until the floor is reached.
+    let mut expected_score = initial_score;
+    let mut steps: u32 = 0;
+
+    loop {
+        env.ledger().set_timestamp(env.ledger().timestamp() + decay_interval);
+
+        let new_score = lifecycle.decay_score(&asset_id);
+
+        if expected_score <= decay_rate {
+            // At or below the floor — the contract must clamp to 1.
+            assert_eq!(
+                new_score,
+                1,
+                "step {}: expected MIN_SCORE_WITH_HISTORY=1 at floor, got {}",
+                steps,
+                new_score,
+            );
+            break;
+        }
+
+        expected_score = expected_score.saturating_sub(decay_rate);
+        assert_eq!(
+            new_score,
+            expected_score,
+            "step {}: expected score {} after one interval of decay but got {}",
+            steps,
+            expected_score,
+            new_score,
+        );
+
+        steps += 1;
+        // Safety valve: a score starting at most 100, decaying by 2 each step,
+        // reaches the floor in at most 50 steps.
+        assert!(
+            steps <= 100,
+            "decay did not converge to floor within 100 steps \
+             (initial_score={}, decay_rate={})",
+            initial_score,
+            decay_rate,
+        );
+    }
+
+    // After the loop the final *stored* score must still be 1.
+    let final_score = lifecycle.get_collateral_score(&asset_id);
+    assert_eq!(
+        final_score,
+        1,
+        "final stored score must be MIN_SCORE_WITH_HISTORY=1, got {}",
+        final_score,
+    );
+}

--- a/tests/test_suspended_engineer_rejected.rs
+++ b/tests/test_suspended_engineer_rejected.rs
@@ -1,0 +1,230 @@
+// tests/test_suspended_engineer_rejected.rs
+//
+// Issue #1033 — Add Test: submit_maintenance by suspended engineer should be rejected
+//
+// Verifies that a suspended engineer (suspension_end_time in the future) cannot
+// submit maintenance records during the suspension window, and that the same
+// engineer is accepted again once the suspension has expired.
+//
+// Test steps:
+//   1. Register asset, engineer, and authorize the engineer for the asset.
+//   2. Confirm a pre-suspension submission succeeds (sanity check).
+//   3. Suspend the engineer with a future end timestamp.
+//   4. Attempt submit_maintenance while suspended — assert UnauthorizedEngineer.
+//   5. Advance ledger past the suspension end time.
+//   6. Attempt submit_maintenance after suspension — assert success.
+
+use asset_registry::{AssetRegistry, AssetRegistryClient};
+use engineer_registry::{EngineerRegistry, EngineerRegistryClient};
+use lifecycle::{Lifecycle, LifecycleClient};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    Address, BytesN, Env, String,
+};
+
+/// lifecycle: ContractError::UnauthorizedEngineer = 2
+const LIFECYCLE_UNAUTHORIZED_ENGINEER: u32 = 2;
+
+// ─── Setup helper ────────────────────────────────────────────────────────────
+
+struct Setup<'a> {
+    env: &'a Env,
+    engineer_registry: EngineerRegistryClient<'a>,
+    lifecycle: LifecycleClient<'a>,
+    /// The asset registered for this test.
+    asset_id: u64,
+    /// The engineer to be suspended.
+    engineer: Address,
+    /// The issuer who credentialed the engineer (required for suspend_engineer).
+    issuer: Address,
+}
+
+impl<'a> Setup<'a> {
+    fn new(env: &'a Env) -> Self {
+        env.mock_all_auths();
+
+        let asset_registry_id = env.register(AssetRegistry, ());
+        let engineer_registry_id = env.register(EngineerRegistry, ());
+        let lifecycle_id = env.register(Lifecycle, ());
+
+        let asset_registry = AssetRegistryClient::new(env, &asset_registry_id);
+        let engineer_registry = EngineerRegistryClient::new(env, &engineer_registry_id);
+        let lifecycle = LifecycleClient::new(env, &lifecycle_id);
+
+        let asset_admin = Address::generate(env);
+        let eng_admin = Address::generate(env);
+        let lc_admin = Address::generate(env);
+        let issuer = Address::generate(env);
+        let owner = Address::generate(env);
+        let engineer = Address::generate(env);
+
+        // Bootstrap asset-registry.
+        asset_registry.initialize_admin(&asset_admin, &asset_admin);
+        asset_registry.add_asset_type(&asset_admin, &symbol_short!("GENSET"));
+
+        // Bootstrap engineer-registry.
+        engineer_registry.initialize_admin(&eng_admin, &eng_admin);
+        engineer_registry.add_trusted_issuer(&eng_admin, &issuer);
+
+        // Bootstrap lifecycle.
+        lifecycle.initialize(
+            &lc_admin,
+            &asset_registry_id,
+            &engineer_registry_id,
+            &lc_admin,
+            &0,
+        );
+
+        // Register an asset.
+        let asset_id = asset_registry.register_asset(
+            &symbol_short!("GENSET"),
+            &String::from_str(env, "Suspension test asset"),
+            &String::from_str(env, "SN-SUSP-1033-001"),
+            &owner,
+        );
+
+        // Register and authorize the engineer.
+        let credential_hash = BytesN::from_array(env, &[0xeeu8; 32]);
+        engineer_registry.register_engineer(
+            &engineer,
+            &credential_hash,
+            &issuer,
+            &31_536_000, // 1-year validity
+            &None,
+        );
+        lifecycle.authorize_engineer(&owner, &asset_id, &engineer);
+
+        Setup {
+            env,
+            engineer_registry,
+            lifecycle,
+            asset_id,
+            engineer,
+            issuer,
+        }
+    }
+}
+
+// ─── Issue #1033 tests ────────────────────────────────────────────────────────
+
+/// A suspended engineer must not be able to submit maintenance records.
+///
+/// Steps:
+///   1. Confirm a pre-suspension submission succeeds.
+///   2. Suspend the engineer for one hour.
+///   3. Assert that submit_maintenance is rejected with
+///      ContractError::UnauthorizedEngineer (code 2) while suspended.
+///   4. Assert the maintenance history was not extended by the rejected call.
+#[test]
+fn test_suspended_engineer_cannot_submit_maintenance() {
+    let env = Env::default();
+    let s = Setup::new(&env);
+
+    // ── Step 1: pre-suspension submission must succeed ────────────────────────
+    s.lifecycle.submit_maintenance(
+        &s.asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Pre-suspension service — should succeed"),
+        &s.engineer,
+    );
+    let history_len_before = s.lifecycle.get_maintenance_history(&s.asset_id).len();
+    assert_eq!(
+        history_len_before, 1,
+        "expected exactly one record before suspension",
+    );
+
+    // ── Step 2: suspend the engineer for 1 hour ───────────────────────────────
+    let now = env.ledger().timestamp();
+    let suspension_end = now + 3_600; // 1 hour from now
+    s.engineer_registry.suspend_engineer(
+        &s.engineer,
+        &suspension_end,
+        &String::from_str(&env, "Ongoing investigation"),
+    );
+
+    // ── Step 3: attempt submission while suspended ────────────────────────────
+    let result = s.lifecycle.try_submit_maintenance(
+        &s.asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "During-suspension attempt — must be rejected"),
+        &s.engineer,
+    );
+
+    assert_eq!(
+        result,
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            LIFECYCLE_UNAUTHORIZED_ENGINEER,
+        ))),
+        "submit_maintenance must return UnauthorizedEngineer (error {LIFECYCLE_UNAUTHORIZED_ENGINEER}) \
+         while the engineer is suspended",
+    );
+
+    // ── Step 4: history must not have grown ───────────────────────────────────
+    let history_len_after = s.lifecycle.get_maintenance_history(&s.asset_id).len();
+    assert_eq!(
+        history_len_after, history_len_before,
+        "maintenance history must not grow when the submission is rejected",
+    );
+}
+
+/// A previously-suspended engineer can submit maintenance records again once
+/// the suspension window has elapsed.
+///
+/// Steps:
+///   1. Suspend the engineer for 1 hour.
+///   2. Confirm submission is rejected during suspension.
+///   3. Advance the ledger to exactly the suspension end timestamp.
+///   4. Assert that submit_maintenance now succeeds.
+#[test]
+fn test_engineer_can_submit_maintenance_after_suspension_expires() {
+    let env = Env::default();
+    let s = Setup::new(&env);
+
+    // ── Step 1: suspend the engineer for 1 hour ───────────────────────────────
+    let now = env.ledger().timestamp();
+    let suspension_end = now + 3_600;
+    s.engineer_registry.suspend_engineer(
+        &s.engineer,
+        &suspension_end,
+        &String::from_str(&env, "Temporary suspension"),
+    );
+
+    // ── Step 2: confirm submission is rejected mid-suspension ─────────────────
+    let mid_suspension = now + 1_800; // 30 minutes in
+    env.ledger().set_timestamp(mid_suspension);
+
+    let rejected = s.lifecycle.try_submit_maintenance(
+        &s.asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Mid-suspension attempt — must be rejected"),
+        &s.engineer,
+    );
+
+    assert_eq!(
+        rejected,
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            LIFECYCLE_UNAUTHORIZED_ENGINEER,
+        ))),
+        "submit_maintenance must be rejected mid-suspension",
+    );
+
+    // ── Step 3: advance to the suspension end timestamp ───────────────────────
+    // The suspension window is defined as timestamp < suspension_end_time, so
+    // at exactly suspension_end the engineer's status must revert to Valid.
+    env.ledger().set_timestamp(suspension_end);
+
+    // ── Step 4: submission after suspension must succeed ─────────────────────
+    s.lifecycle.submit_maintenance(
+        &s.asset_id,
+        &symbol_short!("OIL_CHG"),
+        &String::from_str(&env, "Post-suspension service — should succeed"),
+        &s.engineer,
+    );
+
+    assert_eq!(
+        s.lifecycle.get_maintenance_history(&s.asset_id).len(),
+        1,
+        "expected exactly one successful maintenance record after suspension expired",
+    );
+}


### PR DESCRIPTION
…1034

Issue #1034 requested a test suite verifying that the collateral score produced by the lifecycle contract's decay logic behaves correctly across multiple decay intervals, clamps at the right floor values, and reaches 0 only for assets with no maintenance history.

## What was done

Four integration tests were added to a new file:
  tests/test_collateral_score_decay_intervals.rs

The file was also registered as a [[test]] target in tests/Cargo.toml so it participates in 'cargo test -p cross-platform-tests' and the CI run.

## How it was done

The tests follow the exact same setup pattern used throughout the existing integration-test suite (test_decay_clamps_at_zero.rs, test_collateral_score_cap.rs, etc.):

  1. Env::default() + mock_all_auths()
  2. Register AssetRegistry, EngineerRegistry, and Lifecycle contracts
  3. Initialize all three contracts
  4. Register an asset via asset_registry.register_asset
  5. Register an engineer via engineer_registry.register_engineer
  6. Authorize the engineer for the asset via lifecycle.authorize_engineer
  7. Submit maintenance records via lifecycle.submit_maintenance to build a stored collateral score
  8. Optionally configure custom decay parameters via lifecycle.update_decay_config(admin, decay_rate, decay_interval)
  9. Advance the ledger timestamp with env.ledger().set_timestamp(...)
 10. Call lifecycle.decay_score(&asset_id) and assert the expected value

Two shared helpers were extracted to avoid repetition:
  - setup_contracts()   — boots all three contracts, returns their clients
                          plus the lifecycle admin address
  - register_asset()    — registers a GENSET asset, returns (asset_id, owner)
  - register_and_authorize_engineer() — registers an engineer with a given
                          credential-hash seed and authorises it for an asset

## The four test cases

### test_score_decrements_by_decay_rate_over_three_intervals Verifies that after 3 × decay_interval seconds have elapsed, calling decay_score returns exactly initial_score − 3 × decay_rate. Custom config: rate = 3, interval = 60 s.
Asserts: decayed_score == initial.saturating_sub(9).

### test_score_clamped_at_min_score_with_history_for_maintained_asset Verifies the MIN_SCORE_WITH_HISTORY = 1 floor: when an asset has at least one maintenance record, apply_decay must never return 0 regardless of how much time has elapsed.  An aggressive config (rate = 50, interval = 10 s) combined with a 10,000-second advance guarantees the raw computation saturates to 0, after which the floor must kick in and return 1. Also asserts is_collateral_eligible returns false (score 1 < threshold 50).

### test_score_is_zero_for_asset_with_no_maintenance_history Verifies the complementary rule: an asset with NO maintenance records must score exactly 0 from decay_score — the MIN_SCORE_WITH_HISTORY floor must NOT apply.  This test registers an asset, skips all maintenance submissions, advances the clock, and asserts decay_score == 0 and is_collateral_eligible == false.

### test_score_decrements_step_by_step_each_interval Drives the decay loop step-by-step: advance one interval at a time, calling decay_score after each advance, and assert the score drops by exactly decay_rate at every step until the floor (1) is reached. Custom config: rate = 2, interval = 30 s.  A final call to get_collateral_score confirms the floor value is persisted in storage.

## Key constants exercised

  DEFAULT_DECAY_RATE     = 5   (contracts/lifecycle/src/lib.rs)
  DEFAULT_DECAY_INTERVAL = DEFAULT_DECAY_INTERVAL_SECS (shared crate)
  MIN_SCORE_WITH_HISTORY = 1   (contracts/lifecycle/src/lib.rs)

The tests use update_decay_config to set controlled values so assertions are deterministic and independent of the shared-crate constant values.

## Summary

Describe the purpose of this pull request and the changes it introduces.

## Changes
Closes #1034 
- 
- 

## Testing

Describe how this was tested and any important validation details.

## Changelog

- [ ] I have updated `CHANGELOG.md` with this PR's changes

If this PR introduces user-facing changes, be sure to add an entry under the appropriate category (Added, Changed, Fixed, Removed, Deprecated, Security) in the `## [Unreleased]` section of `CHANGELOG.md`.

See `CONTRIBUTING.md` for changelog guidelines and examples.

## Notes

See `CONTRIBUTING.md` for contribution and review guidance.
