### PR TITLE
tests(engineer-registry): verify credential renewal extends expires_at correctly

### DIFF
--- a/tests/test_credential_renewal_extends_expiry.rs
+++ b/tests/test_credential_renewal_extends_expiry.rs
@@ -1,0 +1,94 @@
+// tests/test_credential_renewal_extends_expiry.rs
+//
+// Issue #1041 — Add Test: engineer registry credential renewal extends
+// expires_at correctly
+//
+// Verifies that renewing a credential moves `expires_at` forward relative to
+// its state at renewal time, rather than leaving it pinned to a value that
+// could be derived purely from the original registration.
+//
+// Per `renew_credential`'s documented behaviour (contracts/engineer-registry/
+// src/lib.rs), a credential that has not yet hard-expired renews by adding
+// the new validity period on top of its *current* `expires_at` — preserving
+// whatever validity remained rather than resetting from "now". This test
+// exercises exactly that path:
+//
+//   1. Register engineer with a 30-day credential.
+//   2. Advance the ledger 20 days (10 days of the original period remain).
+//   3. Renew the credential for another 30 days.
+//   4. Assert the new `expires_at` is computed from the renewal-time state
+//      (current `expires_at`), not simply reproducing the original
+//      registration's `issued_at + 30 days` value untouched.
+
+use engineer_registry::{EngineerRegistry, EngineerRegistryClient};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, BytesN, Env};
+
+const DAY: u64 = 86_400;
+
+#[test]
+fn test_renew_credential_extends_expires_at_correctly() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(EngineerRegistry, ());
+    let client = EngineerRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize_admin(&admin, &admin);
+
+    let issuer = Address::generate(&env);
+    client.add_trusted_issuer(&admin, &issuer);
+
+    // 1. Register engineer with a 30-day credential.
+    let engineer = Address::generate(&env);
+    let credential_hash = BytesN::from_array(&env, &[0x11u8; 32]);
+    let issued_at = env.ledger().timestamp();
+    let initial_validity = 30 * DAY;
+    client.register_engineer(&engineer, &credential_hash, &issuer, &initial_validity, &None);
+
+    let original = client.get_engineer(&engineer);
+    let original_expires_at = original.expires_at;
+    assert_eq!(original_expires_at, issued_at + initial_validity);
+
+    // 2. Advance ledger 20 days — credential is still valid (10 days remain).
+    let elapsed = 20 * DAY;
+    env.ledger().set_timestamp(issued_at + elapsed);
+    let renewal_time = env.ledger().timestamp();
+    assert_eq!(renewal_time, issued_at + elapsed);
+
+    // 3. Renew credential for another 30 days.
+    let new_validity = 30 * DAY;
+    client.renew_credential(&engineer, &new_validity);
+
+    // 4. The new expires_at must reflect the renewal — it is calculated
+    //    relative to the credential's current state (its still-active
+    //    expires_at) at renewal time, not a value that ignores the renewal
+    //    entirely.
+    let renewed = client.get_engineer(&engineer);
+
+    // A broken renewal that failed to move the expiry forward at all would
+    // leave expires_at exactly at the original registration's value; that
+    // must not happen.
+    assert_ne!(
+        renewed.expires_at, original_expires_at,
+        "renew_credential must change expires_at, not leave it at the pre-renewal value"
+    );
+
+    // Correct, documented behaviour: since the credential had not yet
+    // expired, the new period stacks on the current expires_at.
+    let expected_expires_at = original_expires_at + new_validity;
+    assert_eq!(
+        renewed.expires_at, expected_expires_at,
+        "renewal must extend from the credential's current expires_at, not reset from renewal time"
+    );
+
+    // The renewed expiry must land strictly after "renewal_time + new_validity"
+    // would give — confirming the remaining validity at renewal time was
+    // preserved rather than discarded.
+    assert!(
+        renewed.expires_at > renewal_time + new_validity,
+        "renewed expires_at ({}) must exceed a naive renewal_time + validity ({})",
+        renewed.expires_at,
+        renewal_time + new_validity
+    );
+}


### PR DESCRIPTION
## Summary
- Adds an integration test that registers an engineer with a 30-day credential, advances the ledger 20 days, renews for another 30 days, and asserts `expires_at` is correctly extended from the credential's state at renewal time rather than staying pinned to the original registration.
- Per `renew_credential`'s documented behavior, a not-yet-expired credential renews by adding the new validity period on top of its *current* `expires_at` (preserving remaining validity). The test asserts this exact formula and also asserts the naive "renewal_time + validity" value is exceeded, confirming remaining validity isn't discarded.

Closes #1041

## Known issue (pre-existing, unrelated to this PR)
`main` currently fails to build: `contracts/asset-registry/src/lib.rs` and `contracts/engineer-registry/src/lib.rs` both have brace-mismatched/duplicated test code from prior merges (confirmed via brace-count mismatch and multiple `unclosed delimiter` compiler errors spanning thousands of lines). This means `cargo test` cannot currently run for **any** branch off `main`, including this one — it is not something introduced by this change. Flagging here since CI will fail until that's fixed separately.

## Test plan
- [ ] Once the pre-existing build breakage in `engineer-registry`/`asset-registry` is fixed, run `cargo test -p cross-platform-tests test_renew_credential_extends_expires_at_correctly`
- [x] Manually verified test logic and all called function signatures (`register_engineer`, `renew_credential`, `get_engineer`) against current `contracts/engineer-registry/src/lib.rs` source

🤖 Generated with [Claude Code](https://claude.com/claude-code)