### PR TITLE
Fix/1069 1070 credential status and lifecycle score sentinel

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -225,6 +225,12 @@ pub const DEREG_TOPIC: Symbol = symbol_short!("DEREG");
 pub const ADD_TYPE_TOPIC: Symbol = symbol_short!("ADD_TYPE");
 pub const RM_TYPE_TOPIC: Symbol = symbol_short!("RM_TYPE");
 
+/// Sentinel score returned by [`AssetRegistry::get_lifecycle_score`] for assets that
+/// have never had a maintenance record submitted. Distinguishes a brand-new asset
+/// from one with an actual score of 0 (e.g. deprecated or decommissioned), so DeFi
+/// lenders don't mistake "no history yet" for "poor maintenance record".
+pub const NO_LIFECYCLE_HISTORY_SCORE: u32 = u32::MAX;
+
 fn asset_key(id: u64) -> (Symbol, u64) {
     (symbol_short!("ASSET"), id)
 }
@@ -2119,7 +2125,9 @@ impl AssetRegistry {
     /// * `lifecycle_contract` - The address of the Lifecycle contract
     ///
     /// # Returns
-    /// The collateral score (u32) for the asset
+    /// The collateral score (u32) for the asset, or [`NO_LIFECYCLE_HISTORY_SCORE`]
+    /// if the asset has never had a maintenance record submitted. This sentinel lets
+    /// callers distinguish a brand-new asset from one with an actual score of 0.
     ///
     /// # Panics
     /// - [`ContractError::AssetNotFound`] if the asset does not exist
@@ -2135,6 +2143,19 @@ impl AssetRegistry {
             &env,
             soroban_sdk::IntoVal::<Env, soroban_sdk::Val>::into_val(&asset_id, &env)
         ];
+
+        // A fresh asset with no maintenance history at all must be reported with the
+        // sentinel rather than the raw score, which would otherwise read as 0 and be
+        // indistinguishable from a poorly-maintained (also-0) asset.
+        let last_service: Option<u64> = env.invoke_contract(
+            &lifecycle_contract,
+            &Symbol::new(&env, "get_last_service_timestamp"),
+            args.clone(),
+        );
+        if last_service.is_none() {
+            return NO_LIFECYCLE_HISTORY_SCORE;
+        }
+
         let score: u32 = env.invoke_contract(
             &lifecycle_contract,
             &Symbol::new(&env, "get_collateral_score"),
@@ -5672,8 +5693,8 @@ mod tests {
         // Get lifecycle score via cross-contract call
         let score = asset_client.get_lifecycle_score(&asset_id, &lifecycle_id);
 
-        // Score should be a valid u32 (initially 0 for new asset)
-        assert_eq!(score, 0);
+        // A fresh asset with no maintenance history returns the sentinel, not 0.
+        assert_eq!(score, NO_LIFECYCLE_HISTORY_SCORE);
     }
 
     #[test]

--- a/tests/test_full_lifecycle_e2e.rs
+++ b/tests/test_full_lifecycle_e2e.rs
@@ -1,5 +1,5 @@
 use asset_registry::{AssetRegistry, AssetRegistryClient};
-use engineer_registry::{EngineerRegistry, EngineerRegistryClient, EngineerStatus};
+use engineer_registry::{CredentialStatus, EngineerRegistry, EngineerRegistryClient, EngineerStatus};
 use lifecycle::{Lifecycle, LifecycleClient};
 use soroban_sdk::{
     symbol_short,
@@ -54,7 +54,7 @@ fn test_full_lifecycle_e2e() {
     assert_eq!(engineer_record.issuer, issuer);
     assert!(engineer_record.active);
 
-    assert!(engineer_registry.verify_engineer(&engineer));
+    assert_eq!(engineer_registry.verify_engineer(&engineer), CredentialStatus::Valid);
     assert_eq!(
         engineer_registry.get_engineer_status(&engineer),
         EngineerStatus::Active

--- a/tests/test_upgrade_compatibility.rs
+++ b/tests/test_upgrade_compatibility.rs
@@ -58,7 +58,7 @@
 /// to stay within gas limits.
 
 use asset_registry::{AssetRegistry, AssetRegistryClient};
-use engineer_registry::{EngineerRegistry, EngineerRegistryClient};
+use engineer_registry::{CredentialStatus, EngineerRegistry, EngineerRegistryClient};
 use lending::{LendingContract, LendingContractClient};
 use lifecycle::{Lifecycle, LifecycleClient};
 use soroban_sdk::{
@@ -167,9 +167,10 @@ fn test_engineer_registry_data_survives_upgrade() {
 
     // ── Verify credential verification works ────────────────────────
     let verified = er.verify_engineer(&engineer);
-    assert!(
+    assert_eq!(
         verified,
-        "verify_engineer must return true for active credential"
+        CredentialStatus::Valid,
+        "verify_engineer must return Valid for active credential"
     );
 
     // ── Simulate post-upgrade ledger advance ────────────────────────
@@ -179,8 +180,9 @@ fn test_engineer_registry_data_survives_upgrade() {
 
     // ── Credential must still be verifiable ──────────────────────────
     let verified_after = er.verify_engineer(&engineer);
-    assert!(
+    assert_eq!(
         verified_after,
+        CredentialStatus::Valid,
         "Credential must remain valid after simulated upgrade"
     );
 }


### PR DESCRIPTION
## Summary

- Fixes stale `verify_engineer` call sites in the top-level `tests` crate that still treated its return value as a `bool`, even though `verify_engineer` was already changed to return the `CredentialStatus` enum in a prior fix (commit `2980e47`). These call sites (`tests/test_full_lifecycle_e2e.rs`, `tests/test_upgrade_compatibility.rs`) no longer compile against the current `engineer-registry` API — this PR brings them in line with `CredentialStatus::Valid`.
- Fixes `AssetRegistry::get_lifecycle_score`, which returned `0` for a freshly registered asset with no maintenance history — indistinguishable from an asset with an actual score of `0` (deprecated/decommissioned). It now returns a `NO_LIFECYCLE_HISTORY_SCORE` (`u32::MAX`) sentinel when the lifecycle contract reports no maintenance has ever been submitted for the asset, so DeFi lenders can tell "no history yet" apart from "poor maintenance record".

## Details

- `contracts/asset-registry/src/lib.rs`: added `NO_LIFECYCLE_HISTORY_SCORE` constant; `get_lifecycle_score` now first cross-calls `get_last_service_timestamp` on the lifecycle contract, and only proceeds to fetch the real `get_collateral_score` if maintenance history exists. Updated the existing (pre-existing-`#[ignore]`d, due to an unrelated Soroban reentrancy limitation on this cross-contract path) test to assert the sentinel instead of `0`.
- `tests/test_full_lifecycle_e2e.rs`, `tests/test_upgrade_compatibility.rs`: updated `verify_engineer` assertions to compare against `CredentialStatus::Valid` instead of treating the result as a bool.

## Test plan

- [ ] `cargo test` across the workspace (could not be run in this environment — no `cargo` available)
- [x] Manually reviewed all `verify_engineer` call sites in the repo for remaining bool-style usage
- [x] Manually reviewed all callers of `get_lifecycle_score` for sentinel-compatibility (none outside `asset-registry`)

Closes #1069
Closes #1070
