### PR TITLE
Fix/1067 1068 dedup and maintenance checks

### DIFF
--- a/contracts/asset-registry/src/lib.rs
+++ b/contracts/asset-registry/src/lib.rs
@@ -2682,6 +2682,48 @@ mod tests {
         );
     }
 
+    /// Closes #1067 — the owner+metadata dedup key must reject a duplicate even
+    /// when the serial number differs, proving this check is independent from
+    /// (and not merely a side effect of) the serial-number dedup check.
+    #[test]
+    fn test_register_asset_same_owner_metadata_different_serial_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(AssetRegistry, ());
+        let client = AssetRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize_admin(&admin, &admin);
+        client.add_asset_type(&admin, &symbol_short!("GENSET"));
+
+        let owner = Address::generate(&env);
+        let metadata = String::from_str(&env, "CAT-3516-SAME-METADATA");
+
+        let id = client.register_asset(
+            &symbol_short!("GENSET"),
+            &metadata,
+            &String::from_str(&env, "SN-FIRST-001"),
+            &owner,
+        );
+        assert_eq!(id, 1);
+
+        // Same owner + same metadata, but a distinct serial number: the
+        // secondary (owner, asset_type, metadata_hash) dedup key must still
+        // reject this as a duplicate asset.
+        let result = client.try_register_asset(
+            &symbol_short!("GENSET"),
+            &metadata,
+            &String::from_str(&env, "SN-SECOND-002"),
+            &owner,
+        );
+        assert_eq!(
+            result,
+            Err(Ok(soroban_sdk::Error::from_contract_error(
+                ContractError::DuplicateAsset as u32
+            )))
+        );
+    }
+
     #[test]
     fn test_different_owners_same_metadata_allowed() {
         let env = Env::default();

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -4461,6 +4461,7 @@ mod tests {
             &Priority::Low,
             &String::from_str(&env, "Should fail"),
             &engineer,
+            &None,
         );
 
         assert_eq!(


### PR DESCRIPTION
## Summary
Both issues describe protections that are already implemented on `main`:

- `register_asset` already rejects duplicates via two dedup keys — a global
  serial-number key and an (owner, asset_type, metadata_hash) key — checked
  before any write (contracts/asset-registry/src/lib.rs). Landed in 4da63ba.
- `submit_maintenance` already verifies the asset exists via
  `verify_asset_exists`, panicking with `ContractError::AssetNotFound`
  otherwise (contracts/lifecycle/src/lib.rs). Landed in 9cd8f2e.

This PR closes the remaining gaps in test coverage rather than changing
contract logic:

- **#1067**: existing tests only proved the *serial-number* dedup path.
  Added a test proving the *owner+metadata* dedup key independently
  rejects a duplicate even when the serial number differs.
- **#1068**: the existing `test_submit_maintenance_nonexistent_asset`
  regression test was out of sync with `submit_maintenance`'s current
  signature (missing the `cost` argument added by a separate, unrelated
  in-progress commit) and needed a one-line fix to match.

## Known unrelated blocker (not fixed here, out of scope)
`contracts/lifecycle/src/lib.rs` currently fails to compile: a WIP commit
introduced a `priority: Priority` parameter on `submit_maintenance` and a
`priority` field write on `MaintenanceRecord`, but `Priority` is never
defined anywhere in the crate, and `MaintenanceRecord` (types.rs) has no
`priority` field. ~96 of 178 `submit_maintenance` call sites in that file
also still use the old 4-argument signature. This is unrelated to #1067/#1068
and large enough (missing type, missing struct field, ~96 call sites) that
it should be its own PR rather than folded into this one.

## Test plan
- [ ] `cargo test -p asset-registry` — new dedup test passes
- [ ] Once the unrelated lifecycle compile blocker above is resolved,
      `cargo test -p lifecycle test_submit_maintenance_nonexistent_asset`

Closes #1067
Closes #1068
