### PR TITLE
docs: add worked examples to collateral scoring model

### DIFF
--- a/docs/collateral-scoring.md
+++ b/docs/collateral-scoring.md
@@ -83,6 +83,47 @@ Maintenance tasks are categorized into three tiers with different point values:
 - **Default Weight**: 3 points
 - Applied to any task type not explicitly categorized
 
+### Default weights and rationale
+
+| Task type | Weight | Rationale |
+|-----------|-------:|-----------|
+| `OIL_CHG` | 2 | Routine consumable service; low cost, frequent cadence, minimal impact on asset longevity per event. |
+| `LUBE` | 2 | Preventive, low-cost, high-frequency task with a small marginal effect on collateral value. |
+| `INSPECT` | 2 | Diagnostic only — verifies condition but does not itself extend asset life, so it is weighted like other minor tasks. |
+| `FILTER` | 5 | Protects core components (engine/fuel system) from contamination; moderate cost and moderate impact on reliability. |
+| `TUNE_UP` | 5 | Restores performance and efficiency; broader scope than a single-part swap, so weighted above minor tasks. |
+| `BRAKE` | 5 | Safety-critical system service; weighted at the medium tier to reflect both cost and risk mitigation. |
+| `ENGINE` | 10 | High cost, directly extends the useful life of the highest-value component on most DePIN hardware. |
+| `OVERHAUL` | 10 | Comprehensive multi-system rebuild; the strongest signal of long-term asset care available. |
+| `REBUILD` | 10 | Equivalent scope/cost to an overhaul — restores the asset close to as-new condition. |
+| *(unrecognized)* | 3 | Default for task types outside the allowlist; deliberately between minor and medium so unknown work is never over- or under-credited. |
+
+### Worked Example: 5 Maintenance Records Over 90 Days
+
+A minimal example isolating just the decay/score interaction, using the documented defaults (`decay_rate = 5`, `decay_interval = 30 days`, `score_increment` via task weights):
+
+| # | Day | Task | Weight | Days since prior | Decay before event | Score after decay | Score after event |
+|--:|----:|------|-------:|------------------:|--------------------:|-------------------:|--------------------:|
+| — | 0 (registration) | — | — | — | — | — | **0** |
+| 1 | 0 | `ENGINE` | 10 | 0 | 0 | 0 | **10** |
+| 2 | 18 | `FILTER` | 5 | 18 | `floor(18/30)*5 = 0` | 10 | **15** |
+| 3 | 40 | `BRAKE` | 5 | 22 | `floor(22/30)*5 = 0` | 15 | **20** |
+| 4 | 65 | `OVERHAUL` | 10 | 25 | `floor(25/30)*5 = 0` | 20 | **30** |
+| 5 | 90 | `TUNE_UP` | 5 | 25 | `floor(25/30)*5 = 0` | 30 | **35** |
+
+At registration (day 0, before any record) the score is **0** — no maintenance history yet. After the 5th record on day 90, the score is **35**.
+
+**After 60 further days of inactivity** (day 150, no new records):
+
+```text
+elapsed_time = 60 days
+decay_intervals = floor(60 / 30) = 2
+total_decay = 2 * 5 = 10
+new_score = max(35 - 10, 0) = 25
+```
+
+Score at day 150: **25** (still above the score floor of 1 since the asset has maintenance history, and below the default eligibility threshold of 50 — this asset would not be collateral-eligible at that point).
+
 ## Time-Based Decay
 
 ### Default Decay Configuration


### PR DESCRIPTION
## Summary
`docs/collateral-scoring.md` already had a 12-month worked example and per-tier weight buckets, but lacked the specific scenario lenders asked for (a short 5-record/90-day window) and a rationale for each individual task-type weight.

## Changes
- Added "Worked Example: 5 Maintenance Records Over 90 Days" showing score at registration (0), after each of the 5 records, and after 60 further days of inactivity (35 → 25, dropping below the default 50-point eligibility threshold).
- Added a "Default weights and rationale" table covering all 10 task types (`OIL_CHG`, `LUBE`, `INSPECT`, `FILTER`, `TUNE_UP`, `BRAKE`, `ENGINE`, `OVERHAUL`, `REBUILD`, and the unrecognized-type default) explaining why each sits at its point tier.

## Testing
Hand-verified all decay/score arithmetic in the new table against the documented formula (`floor(days/30) * decay_rate`, additive task weights, clamped to [0, 100]).

Closes #1048