### PR TITLE
docs: add rustdoc to all public functions across core contracts

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -3015,6 +3015,25 @@ pub fn accept_admin(env: Env) {
         Some(apply_decay(&env, asset_id, false, false, config.max_history))
     }
 
+    /// Returns the current collateral score for each requested asset.
+    ///
+    /// # Parameters
+    /// - `asset_ids`: the list of asset IDs to score.
+    ///
+    /// # Errors
+    /// Does not panic on a missing or deprecated asset; instead it is skipped
+    /// from the returned list. Panics with [`ContractError::NotInitialized`]
+    /// if the contract has not been initialized.
+    ///
+    /// # Events
+    /// None. This is a read-only batch query and does not mutate storage or
+    /// emit events (equivalent to calling `get_collateral_score` with
+    /// `write = false` for each ID, so no decay is persisted).
+    ///
+    /// # Soroban notes
+    /// Performs one cross-contract call to AssetRegistry per asset ID via
+    /// `try_get_asset`, so callers should keep `asset_ids` reasonably small
+    /// to stay within the transaction's CPU/instruction budget.
     pub fn get_collateral_score_batch(env: Env, asset_ids: Vec<u64>) -> Vec<(u64, u32)> {
         let config: Config = env
             .storage()


### PR DESCRIPTION
## Summary
Audited every `pub fn` in `contracts/lifecycle`, `contracts/asset-registry`, and `contracts/engineer-registry` for `///` rustdoc coverage. All three contracts were already almost fully documented (including `# Parameters`/`# Errors`/`# Events`-style docs and Soroban-specific notes); `get_collateral_score_batch` in `contracts/lifecycle/src/lib.rs` was the sole undocumented public function.

## Changes
- Added a full rustdoc block to `get_collateral_score_batch`: parameters, error behavior (skips missing/deprecated assets rather than panicking), event behavior (none — read-only), and a Soroban-specific note on the per-asset cross-contract call cost to AssetRegistry.

## Testing
Manual audit via `grep -n "pub fn"` across all three contracts' source files, checking the preceding line for a doc comment. Did not run `cargo doc` locally (no network/dependency install performed per task constraints); the change is a doc-comment-only addition with no code behavior change.

Closes #1047