### PR TITLE
Cap maintenance history page size and clarify health snapshot timestamp field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `apply_decay` in `lifecycle/src/scoring.rs`: enforce `MIN_SCORE_WITH_HISTORY = 1` in both the main decay path and the early-return path so the stored score is never written as 0 for an asset that has at least one maintenance record (closes [#784](https://github.com/TwinTrustMainstay/Mainstay/issues/784))
+- `get_maintenance_history_page` in `lifecycle`: cap the caller-supplied `limit` at `MAX_PAGE_SIZE` (100) so a large `limit` can no longer reintroduce an unbounded, potentially oversized response (closes [#1075](https://github.com/TwinTrustMainstay/Mainstay/issues/1075))
+- `HealthSnapshot` in `lifecycle`: renamed the `timestamp` field to `snapshot_timestamp` to make explicit that it records when the snapshot was captured (closes [#1076](https://github.com/TwinTrustMainstay/Mainstay/issues/1076))
 
 ### Security
 - `initialize_admin` in `asset-registry` already required `deployer.require_auth()`, preventing front-run attacks; the existing `test_initialize_admin_rejects_non_deployer` test and deployment-runbook section 3 now explicitly document this protection (closes [#783](https://github.com/TwinTrustMainstay/Mainstay/issues/783))

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -43,6 +43,10 @@ const DEFAULT_MAX_NOTES_LENGTH: u32 = 256;
 /// for the cross-contract calls and per-record validation performed
 /// inside the batch path.
 pub const MAX_BATCH_SIZE: u32 = 50;
+/// Upper bound on `limit` accepted by [`LifecycleContract::get_maintenance_history_page`].
+/// Without this cap a caller could pass an arbitrarily large `limit` and reintroduce
+/// the unbounded-response failure the paginated endpoint exists to prevent.
+pub const MAX_PAGE_SIZE: u32 = 100;
 const TIMELOCK_DELAY_SECS: u64 = 48 * 60 * 60;
 /// Minimum score returned for an asset that has at least one maintenance record.
 /// Prevents decay from making a legitimately-maintained asset indistinguishable
@@ -2287,7 +2291,8 @@ pub fn accept_admin(env: Env) {
     /// # Arguments
     /// * `asset_id` - The unique identifier of the asset
     /// * `offset` - Zero-based start index for pagination
-    /// * `limit` - Maximum number of records to return (returns empty vec if 0)
+    /// * `limit` - Maximum number of records to return (returns empty vec if 0),
+    ///   capped at [`MAX_PAGE_SIZE`]
     ///
     /// # Returns
     /// Vec containing the requested page of maintenance records
@@ -2317,6 +2322,7 @@ pub fn accept_admin(env: Env) {
             return Vec::new(&env);
         }
 
+        let limit = limit.min(MAX_PAGE_SIZE);
         let end = (offset + limit).min(len);
         let mut page = Vec::new(&env);
         for i in offset..end {
@@ -8851,6 +8857,38 @@ mod tests {
                 ContractError::AssetNotFound as u32,
             ))),
         );
+    }
+
+    #[test]
+    fn test_get_maintenance_history_page_limit_capped_at_max_page_size() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        // max_history=0 → default of 200, comfortably above MAX_PAGE_SIZE (100)
+        // so none of the records submitted below get pruned.
+        let (client, asset_registry_client, engineer_registry_client, _) = setup(&env, 0);
+        let (asset_id, asset_owner) = register_asset(&env, &asset_registry_client);
+        let engineer = register_engineer(&env, &engineer_registry_client);
+        client.authorize_engineer(&asset_owner, &asset_id, &engineer);
+
+        // Submit 150 records (3 batches of 50, MAX_BATCH_SIZE) — more than MAX_PAGE_SIZE.
+        for _ in 0..3 {
+            let mut records = Vec::new(&env);
+            for _ in 0..MAX_BATCH_SIZE {
+                records.push_back(BatchRecord {
+                    task_type: symbol_short!("OIL_CHG"),
+                    notes: String::from_str(&env, "Maintenance record"),
+                });
+            }
+            client.batch_submit_maintenance(&asset_id, &records, &engineer);
+        }
+        assert_eq!(client.get_maintenance_history(&asset_id).len(), 150);
+
+        // Requesting a limit far above MAX_PAGE_SIZE must be clamped, not
+        // return every available record — this is the guard against the
+        // unbounded-response failure the pagination endpoint exists to prevent.
+        let page = client.get_maintenance_history_page(&asset_id, &0, &(MAX_PAGE_SIZE * 10));
+        assert_eq!(page.len(), MAX_PAGE_SIZE);
     }
 
     #[test]

--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -3952,7 +3952,7 @@ pub fn accept_admin(env: Env) {
             .fold(0u64, |acc, t| if t > acc { t } else { acc });
 
         let snapshot = HealthSnapshot {
-            timestamp: env.ledger().timestamp(),
+            snapshot_timestamp: env.ledger().timestamp(),
             score,
             maintenance_count,
             last_service_date,
@@ -11164,7 +11164,7 @@ mod tests {
         assert_eq!(snapshot.score, 0);
         assert_eq!(snapshot.maintenance_count, 0);
         assert_eq!(snapshot.last_service_date, 0);
-        assert_eq!(snapshot.timestamp, env.ledger().timestamp());
+        assert_eq!(snapshot.snapshot_timestamp, env.ledger().timestamp());
     }
 
     #[test]
@@ -11218,7 +11218,7 @@ mod tests {
         let snapshots = client.get_health_snapshots(&asset_id);
         assert_eq!(snapshots.len(), 2, "should have one snapshot per take_health_snapshot call");
         assert!(
-            snapshots.get(1).unwrap().timestamp > snapshots.get(0).unwrap().timestamp,
+            snapshots.get(1).unwrap().snapshot_timestamp > snapshots.get(0).unwrap().snapshot_timestamp,
             "snapshots should be in chronological order"
         );
         assert_eq!(snapshots.get(1).unwrap().maintenance_count, 2);
@@ -11381,7 +11381,7 @@ mod tests {
         let snapshots = client.get_health_snapshots(&asset_id);
         assert!(snapshots.len() >= 2, "should accumulate snapshots");
         assert!(
-            snapshots.get(1).unwrap().timestamp >= snapshots.get(0).unwrap().timestamp,
+            snapshots.get(1).unwrap().snapshot_timestamp >= snapshots.get(0).unwrap().snapshot_timestamp,
             "snapshots should be in chronological order"
         );
         assert_eq!(snapshots.get(1).unwrap().maintenance_count, 2);

--- a/contracts/lifecycle/src/types.rs
+++ b/contracts/lifecycle/src/types.rs
@@ -70,7 +70,7 @@ pub struct TimelockProposal {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HealthSnapshot {
-    pub timestamp: u64,
+    pub snapshot_timestamp: u64,
     pub score: u32,
     pub maintenance_count: u32,
     pub last_service_date: u64,


### PR DESCRIPTION
## Summary

Addresses two `lifecycle` contract bugs: an uncapped pagination `limit` that could still trigger the oversized-response failure it was meant to prevent, and an ambiguously-named timestamp field on health snapshots.

## Changes

- `get_maintenance_history_page` now clamps the caller-supplied `limit` to a new `MAX_PAGE_SIZE` (100) constant, so a large `limit` can no longer reintroduce an unbounded response. (closes #1075)
- `HealthSnapshot.timestamp` renamed to `snapshot_timestamp` for clarity on what it records. (closes #1076)

## Testing

No reliable local test runner was available in this environment, so changes were kept minimal and reviewed by hand; `cargo test` was not run.

- Added `test_get_maintenance_history_page_limit_capped_at_max_page_size`, which submits 150 records and asserts a `limit` of `MAX_PAGE_SIZE * 10` is clamped to exactly `MAX_PAGE_SIZE` records returned.
- `HealthSnapshot`'s existing timestamp assertions (`test_take_health_snapshot_empty_history` and the chronological-ordering checks in the snapshot-accumulation tests) were updated to reference `snapshot_timestamp`; no behavioral change.

## Changelog

- [x] Updated `CHANGELOG.md` under `## [Unreleased] > ### Fixed`.

## Notes

- Note for reviewers: `HealthSnapshot` already stored a working timestamp before this change (added under #875) — `get_maintenance_history_page` also already existed with `offset`/`limit` pagination before this change (predates #1075). Both issues as filed described functionality that was already substantially in place; the changes here close the specific gaps that remained (the missing cap, and the field-name clarity ask) rather than re-implementing from scratch.
- Unrelated to this PR: `test_get_maintenance_history_page_25_records` in `contracts/lifecycle/src/lib.rs` (pre-existing on `main`) is missing its closing brace and will fail to compile as-is — left untouched since it's out of scope for #1075/#1076.

Closes #1075
Closes #1076