### PR TITLE
fix(lifecycle): timelock task weight updates

### DIFF
--- a/contracts/lifecycle/src/lib.rs
+++ b/contracts/lifecycle/src/lib.rs
@@ -1527,6 +1527,8 @@ pub fn accept_admin(env: Env) {
     /// - [`ContractError::NotInitialized`] if contract has not been initialized
     /// - [`ContractError::UnauthorizedAdmin`] if caller is not the admin
     /// - [`ContractError::InvalidConfig`] if weight is 0
+    /// - [`ContractError::ProposalNotFound`] if no task-weight update has been proposed
+    /// - [`ContractError::TimelockNotExpired`] if the proposal is still inside the timelock delay
     pub fn set_task_weight(env: Env, admin: Address, task_type: Symbol, weight: u32) {
         ensure_not_paused(&env);
         admin.require_auth();
@@ -1543,6 +1545,8 @@ pub fn accept_admin(env: Env) {
         if config.admin != admin {
             panic_with_error!(&env, ContractError::UnauthorizedAdmin);
         }
+
+        require_timelock_ready(&env, symbol_short!("TSK_WT"));
 
         config.task_weights.set(task_type.clone(), weight);
         env.storage().persistent().set(&CONFIG, &config);
@@ -4124,6 +4128,16 @@ mod tests {
         )
     }
 
+    fn propose_and_expire_task_weight_timelock(
+        env: &Env,
+        client: &LifecycleClient,
+        admin: &Address,
+    ) {
+        client.propose_config_update(admin, &symbol_short!("TSK_WT"));
+        let base = env.ledger().timestamp();
+        env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+    }
+
     /// Generate a unique serial number string for each test asset registration.
     fn unique_serial(env: &Env) -> String {
         use core::sync::atomic::{AtomicU64, Ordering};
@@ -5154,6 +5168,7 @@ mod tests {
         client.authorize_engineer(&asset_owner, &asset_id, &engineer);
 
         // Set custom weight for OIL_CHG to 20
+        propose_and_expire_task_weight_timelock(&env, &client, &admin);
         client.set_task_weight(&admin, &symbol_short!("OIL_CHG"), &20);
 
         // Submit OIL_CHG maintenance and verify score uses custom weight
@@ -5238,7 +5253,9 @@ mod tests {
         client.authorize_engineer(&asset_owner2, &asset_id2, &engineer);
 
         // Configure different weights
+        propose_and_expire_task_weight_timelock(&env, &client, &admin);
         client.set_task_weight(&admin, &symbol_short!("OIL_CHG"), &10);
+        propose_and_expire_task_weight_timelock(&env, &client, &admin);
         client.set_task_weight(&admin, &symbol_short!("ENGINE"), &50);
 
         // Submit OIL_CHG to asset1

--- a/tests/test_admin_timelock.rs
+++ b/tests/test_admin_timelock.rs
@@ -128,6 +128,46 @@ fn test_admin_timelock_rejects_execution_one_second_before_expiry() {
     );
 }
 
+#[test]
+fn test_set_task_weight_timelock_cannot_be_bypassed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, admin) = setup(&env);
+
+    lifecycle.propose_config_update(&admin, &symbol_short!("TSK_WT"));
+
+    let res = lifecycle.try_set_task_weight(&admin, &symbol_short!("OIL_CHG"), &20u32);
+    assert_eq!(
+        res,
+        Err(Ok(soroban_sdk::Error::from_contract_error(
+            LIFECYCLE_TIMELOCK_NOT_EXPIRED,
+        ))),
+        "set_task_weight must fail with TimelockNotExpired before the timelock expires",
+    );
+}
+
+#[test]
+fn test_set_task_weight_timelock_allows_update_after_expiry() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (lifecycle, admin) = setup(&env);
+
+    lifecycle.propose_config_update(&admin, &symbol_short!("TSK_WT"));
+
+    let base = env.ledger().timestamp();
+    env.ledger().set_timestamp(base + TIMELOCK_DELAY_SECS + 1);
+
+    lifecycle.set_task_weight(&admin, &symbol_short!("OIL_CHG"), &20u32);
+
+    let config = lifecycle.get_config();
+    assert_eq!(
+        config.task_weights.get(symbol_short!("OIL_CHG")).unwrap(),
+        20u32
+    );
+}
+
 // --- Admin transfer timelock tests ---
 
 #[test]


### PR DESCRIPTION
Summary:
- Require the existing 48-hour config timelock before set_task_weight can mutate task weights.
- Add admin timelock tests covering immediate rejection and successful execution after expiry.

Closes #1030

Validation:
- git diff --check
- cargo fmt --check not run: cargo is not installed in this container